### PR TITLE
Fix Gemfile and lockfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,1 +1,3 @@
+source 'https://rubygems.org'
+
 gem 'jekyll'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,5 @@
 GEM
+  remote: https://rubygems.org/
   specs:
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -28,7 +28,7 @@ GEM
       rouge (>= 1.7, < 4)
       safe_yaml (~> 1.0)
     jekyll-sass-converter (1.5.2)
-      sass (>= 3.4)
+      sass (~> 3.4)
     jekyll-watch (2.0.0)
       listen (~> 3.0)
     kramdown (1.16.2)
@@ -39,7 +39,7 @@ GEM
       ruby_dep (~> 1.2)
     mercenary (0.3.6)
     pathutil (0.16.1)
-      forwardable-extended (>= 2.6)
+      forwardable-extended (~> 2.6)
     public_suffix (3.0.2)
     rb-fsevent (0.10.2)
     rb-inotify (0.9.10)
@@ -48,9 +48,10 @@ GEM
     ruby_dep (1.5.0)
     safe_yaml (1.0.4)
     sass (3.5.5)
-      sass-listen (>= 4.0.0)
+      sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
-      rb-inotify (>= 0.9.7, >= 0.9)
+      rb-fsevent (~> 0.9, >= 0.9.4)
+      rb-inotify (~> 0.9, >= 0.9.7)
 
 PLATFORMS
   ruby


### PR DESCRIPTION
Bundler requires at least one gem source ([see docs](http://bundler.io/gemfile.html#gemfiles)). Also, I’ve updated the `Gemfile.lock` since it seems to have been slightly corrupted.