### PR TITLE
add travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+sudo: false
+
+language: ruby
+cache: bundler
+rvm:
+  - 2.5.1
+
+install:
+- bundle install --jobs=3 --retry=3
+- npm install broken-link-checker -g
+
+script:
+- bundle exec jekyll serve --detach --verbose
+- blc --recursiv --follow --requests 10 --verbose http://localhost:4000/

--- a/_config.yml
+++ b/_config.yml
@@ -27,3 +27,4 @@ exclude:
   - README.md
   - Gemfile
   - Gemfile.lock
+  - vendor


### PR DESCRIPTION
just a simple travis setup to build/serve the jekyll site and run a link checker against it. 

I went for  https://github.com/stevenvachon/broken-link-checker to check links because of the current defunc/forked state of the linkchecker python project. (FYI: currently, pgp.mit.edu throws 503 errors on every other request probably due to high load)

Example result: https://travis-ci.org/rmoriz/restic.net/builds/365174240

Within the travis webui you can add a ["cron job"](https://docs.travis-ci.com/user/cron-jobs/) e.g. to run CI on the master branch every day. This will check external links on a regular basis so you don't have to scrape the live site.


(Maybe verbosity of jekyll and blc are not needed)