### PR TITLE
Linkcheck

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,4 @@ script:
   - bundle exec jekyll build --destination _site-new
   - diff -aur --exclude 'feed.xml' _site _site-new
   - bundle exec jekyll serve --detach --verbose --skip-initial-build
-  - linkchecker --verbose http://127.0.0.1:4000
+  - linkchecker http://127.0.0.1:4000

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,10 @@ rvm:
   - 2.5.1
 
 install:
-  - bundle install --jobs=3 --retry=3
+  - pyenv local 2.7.14
   - pip install --user --no-cache-dir git+https://github.com/fd0/linkchecker.git@fix-requirements
   - export PATH=~/.local/bin:$PATH
+  - bundle install --jobs=3 --retry=3
 
 script:
   - bundle exec jekyll build --destination _site-new

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ rvm:
 
 install:
   - bundle install --jobs=3 --retry=3
-  - pip install --user --no-cache-dir git+https://github.com/linkcheck/linkchecker.git@master
+  - pip install --user --no-cache-dir git+https://github.com/fd0/linkchecker.git@fix-requirements
   - export PATH=~/.local/bin:$PATH
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,8 @@ rvm:
 
 install:
   - bundle install --jobs=3 --retry=3
-  - pip install --no-cache-dir git+https://github.com/linkcheck/linkchecker.git@master
+  - pip install --user --no-cache-dir git+https://github.com/linkcheck/linkchecker.git@master
+  - export PATH=~/.local/bin:$PATH
 
 script:
   - bundle exec jekyll serve --detach --verbose --skip-initial-build

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,5 +11,7 @@ install:
   - export PATH=~/.local/bin:$PATH
 
 script:
+  - bundle exec jekyll build --destination _site-new
+  - diff -aur --exclude 'feed.xml' _site _site-new
   - bundle exec jekyll serve --detach --verbose --skip-initial-build
   - linkchecker --verbose http://127.0.0.1:4000

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,9 @@ rvm:
   - 2.5.1
 
 install:
-- bundle install --jobs=3 --retry=3
-- npm install broken-link-checker -g
+  - bundle install --jobs=3 --retry=3
+  - pip install --no-cache-dir git+https://github.com/linkcheck/linkchecker.git@master
 
 script:
-- bundle exec jekyll serve --detach --verbose
-- blc --recursiv --follow --requests 10 --verbose http://localhost:4000/
+  - bundle exec jekyll serve --detach --verbose --skip-initial-build
+  - linkchecker --verbose http://127.0.0.1:4000

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,4 @@ script:
   - bundle exec jekyll build --destination _site-new
   - diff -aur --exclude 'feed.xml' _site _site-new
   - bundle exec jekyll serve --detach --verbose --skip-initial-build
-  - linkchecker http://127.0.0.1:4000
+  - linkchecker --check-extern --no-robots http://127.0.0.1:4000

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+sudo: false
+
+language: ruby
+cache: bundler
+rvm:
+  - 2.5.1
+
+install:
+- bundle install --jobs=3 --retry=3
+- npm install broken-link-checker -g
+
+script:
+- bundle exec jekyll serve --detach --verbose
+- blc --recursiv --follow --requests 10 --verbose http://localhost:4000/

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+|Build Status|
+
 This is the repository for the website content at https://restic.net. The
 website is generated with Jekyll.
 
@@ -5,3 +7,6 @@ The resulting website can be checked for dangling links with `linkchecker`,
 like this:
 
     $ linkchecker --check-extern --no-robots https://restic.net
+
+.. |Build Status| image:: https://travis-ci.org/restic/restic.net.svg?branch=master
+   :target: https://travis-ci.org/restic/restic.net

--- a/_config.yml
+++ b/_config.yml
@@ -27,3 +27,4 @@ exclude:
   - README.md
   - Gemfile
   - Gemfile.lock
+  - vendor


### PR DESCRIPTION
Add CI checks via Travis:
 * [x] Run `linkchecker`
 * [x] Rebuild the site and check for differences, this catches forgotten `jekyll build` and broken markdown files