### PR TITLE
travis: Run only for commits and PRs to the master branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: minimal
 dist: focal
 
+branches:
+  only:
+    - master
+
 install:
   # Install Hugo (must be the "extended" version).
   - curl -LO https://github.com/gohugoio/hugo/releases/download/v0.75.1/hugo_extended_0.75.1_Linux-64bit.deb


### PR DESCRIPTION
Prevents travis from running multiple builds for the same thing.