### PR TITLE
Correct date of latest Changelog podcast talk

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -63,7 +63,7 @@ There are several ways to contact the restic project and its community:
 
 The following talks have been given about restic:
 
- * 2021-03-21: [The Changelog: Restic has your backup (Podcast)](https://changelog.com/podcast/434)
+ * 2021-04-02: [The Changelog: Restic has your backup (Podcast)](https://changelog.com/podcast/434)
  * 2016-01-31: Lightning Talk at the Go Devroom at FOSDEM 2016, Brussels, Belgium
  * 2016-01-29: [restic - Backups mal richtig](https://media.ccc.de/v/c4.openchaos.2016.01.restic): Public lecture in German at [CCC Cologne e.V.](https://koeln.ccc.de) in Cologne, Germany
  * 2015-08-23: [A Solution to the Backup Inconvenience](https://media.ccc.de/browse/conferences/froscon/2015/froscon2015-1515-a_solution_to_the_backup_inconvenience.html): Lecture at [FROSCON 2015](https://www.froscon.de) in Bonn, Germany

--- a/public/index.html
+++ b/public/index.html
@@ -146,7 +146,7 @@
 <h2 id="talks">Talks</h2>
 <p>The following talks have been given about restic:</p>
 <ul>
-<li>2021-03-21: <a href="https://changelog.com/podcast/434">The Changelog: Restic has your backup (Podcast)</a></li>
+<li>2021-04-02: <a href="https://changelog.com/podcast/434">The Changelog: Restic has your backup (Podcast)</a></li>
 <li>2016-01-31: Lightning Talk at the Go Devroom at FOSDEM 2016, Brussels, Belgium</li>
 <li>2016-01-29: <a href="https://media.ccc.de/v/c4.openchaos.2016.01.restic">restic - Backups mal richtig</a>: Public lecture in German at <a href="https://koeln.ccc.de">CCC Cologne e.V.</a> in Cologne, Germany</li>
 <li>2015-08-23: <a href="https://media.ccc.de/browse/conferences/froscon/2015/froscon2015-1515-a_solution_to_the_backup_inconvenience.html">A Solution to the Backup Inconvenience</a>: Lecture at <a href="https://www.froscon.de">FROSCON 2015</a> in Bonn, Germany</li>


### PR DESCRIPTION
The podcast was published on the 2nd of April 2021, match that in the list of talks here on the website.