### PR TITLE
Fix miscellaneous build and link issues

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install muffet
         run: |
           mkdir $HOME/bin
-          curl -L https://github.com/raviqqe/muffet/releases/download/v2.4.2/muffet_2.4.2_Linux_x86_64.tar.gz | tar zx -C $HOME/bin
+          curl -L https://github.com/raviqqe/muffet/releases/download/v2.9.3/muffet_linux_amd64.tar.gz | tar zx -C $HOME/bin
           echo "$HOME/bin" >> $GITHUB_PATH
 
       - name: Check out website

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Build website
         run: |
-          hugo --cleanDestinationDir --destination public-compare --templateMetrics --templateMetricsHints
+          hugo --destination public-compare --templateMetrics --templateMetricsHints
 
       - name: Check for differences
         run: diff -aur public public-compare

--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ To create a new blog post, do the following:
 - To make the post a draft or future publish it, see `here <https://gohugo.io/getting-started/usage/#draft-future-and-expired-content>`__.
 - To embed an image in the post, place the image file in the ``static/blog/`` directory and reference it in the post file like this ``![My fancy image](/blog/my-fancy-image.png)`` (the text will be the alt/description of the image).
 
-To re-generate the website, run ``build.sh`` - this will run Hugo with the proper arguments and the website will be generated in the ``public/`` directory.
+To re-generate the website, run ``hugo`` - this will run Hugo with the proper settings (configured in `hugo.toml`) and the website will be generated in the ``public/`` directory.
 
 .. |Build Status| image:: https://github.com/restic/restic.net/actions/workflows/checks.yml/badge.svg
    :target: https://github.com/restic/restic.net/actions/workflows/checks.yml

--- a/README.rst
+++ b/README.rst
@@ -17,5 +17,5 @@ To create a new blog post, do the following:
 
 To re-generate the website, run ``build.sh`` - this will run Hugo with the proper arguments and the website will be generated in the ``public/`` directory.
 
-.. |Build Status| image:: https://github.com/restic/restic.net/workflows/Build%20and%20Checks/badge.svg
-   :target: https://github.com/restic/restic.net/actions?query=workflow%3A%22Build+and+Checks%22
+.. |Build Status| image:: https://github.com/restic/restic.net/actions/workflows/checks.yml/badge.svg
+   :target: https://github.com/restic/restic.net/actions/workflows/checks.yml

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-# Use --cleanDestinationDir to not leave stale files behind.
-hugo --cleanDestinationDir

--- a/content/_index.md
+++ b/content/_index.md
@@ -68,7 +68,7 @@ The following talks have been given about restic:
  * 2016-01-29: [restic - Backups mal richtig](https://media.ccc.de/v/c4.openchaos.2016.01.restic): Public lecture in German at [CCC Cologne e.V.](https://koeln.ccc.de) in Cologne, Germany
  * 2015-08-23: [A Solution to the Backup Inconvenience](https://media.ccc.de/browse/conferences/froscon/2015/froscon2015-1515-a_solution_to_the_backup_inconvenience.html): Lecture at [FROSCON 2015](https://www.froscon.de) in Bonn, Germany
  * 2015-02-01: [Lightning Talk at FOSDEM 2015](https://www.youtube.com/watch?v=oM-MfeflUZ8&t=11m40s): A short introduction (with slightly outdated command line)
- * 2015-01-27: [Talk about restic at CCC Aachen](https://videoag.fsmpi.rwth-aachen.de/?view=player&lectureid=4442) (in German)
+ * 2015-01-27: [Talk about restic at CCC Aachen](https://video.fsmpi.rwth-aachen.de/cccac/4442) (in German)
 
 ## Blog
 

--- a/content/blog/Documentation.md
+++ b/content/blog/Documentation.md
@@ -34,7 +34,7 @@ without any third-party software. We'll always try to make the documentation
 readable in plain text.
 
 Additionally we've enabled the awesome
-[Read the Docs](https://readthedocs.org/) service, which allows reading the
+[Read the Docs](https://about.readthedocs.com/) service, which allows reading the
 documentation at <https://restic.readthedocs.io/>. In the bottom left corner
 is a small menu which allows switching to a specific version of the
 documentation. The URL <https://restic.readthedocs.io/en/latest/> will always

--- a/hugo.toml
+++ b/hugo.toml
@@ -5,8 +5,14 @@ title = "restic"
 # Stay compatible with URLs from the previous (Jekyll) website.
 disablePathToLower = true
 
-# Don't automatically inject the "Hugo 0.x.y" meta tag
+# Don't automatically inject the "Hugo 0.x.y" meta tag.
 disableHugoGeneratorInject = true
+
+# Remove files that should no longer exist.
+cleanDestinationDir = true
+
+# Include content with a future publish date.
+buildFuture = true
 
 [params]
 	tagline = "Backups done right!"

--- a/layouts/partials/github.html
+++ b/layouts/partials/github.html
@@ -1,3 +1,24 @@
-<a href="https://github.com/restic/restic" class="desktop">
-	<img style="position: fixed; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/38ef81f8aca64bb9a64448d0d70f1308ef5341ab/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png">
+<!--
+	Source: https://github.com/tholman/github-corners
+
+	The MIT License (MIT)
+
+	Copyright (c) 2016 Tim Holman
+
+	Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+	The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+	THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+-->
+<a href="https://github.com/restic/restic" class="github-corner desktop" aria-label="View restic on GitHub">
+	<svg width="80" height="80" viewBox="0 0 250 250" style="fill:#202020; color:#fff; position: absolute; top: 0; border: 0; right: 0;" aria-hidden="true">
+		<title>View restic on GitHub</title>
+		<path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
+		<path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path>
+		<path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path>
+	</svg>
 </a>
+<style>
+	.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}
+</style>

--- a/public/blog/2015-09-12/FROSCON-2015-talk-about-restic/index.html
+++ b/public/blog/2015-09-12/FROSCON-2015-talk-about-restic/index.html
@@ -122,8 +122,18 @@ If you do so, please <del><a href="">leave feedback</a></del><sup>1</sup></p>
       </div>
     </div>
 
-    <a href="https://github.com/restic/restic" class="desktop">
-	<img style="position: fixed; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/38ef81f8aca64bb9a64448d0d70f1308ef5341ab/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png">
+    
+<a href="https://github.com/restic/restic" class="github-corner desktop" aria-label="View restic on GitHub">
+	<svg width="80" height="80" viewBox="0 0 250 250" style="fill:#202020; color:#fff; position: absolute; top: 0; border: 0; right: 0;" aria-hidden="true">
+		<title>View restic on GitHub</title>
+		<path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
+		<path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path>
+		<path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path>
+	</svg>
 </a>
+<style>
+	.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}
+</style>
+
   </body>
 </html>

--- a/public/blog/2015-09-12/intro/index.html
+++ b/public/blog/2015-09-12/intro/index.html
@@ -119,8 +119,18 @@ tricks for using restic more efficiently.</p>
       </div>
     </div>
 
-    <a href="https://github.com/restic/restic" class="desktop">
-	<img style="position: fixed; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/38ef81f8aca64bb9a64448d0d70f1308ef5341ab/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png">
+    
+<a href="https://github.com/restic/restic" class="github-corner desktop" aria-label="View restic on GitHub">
+	<svg width="80" height="80" viewBox="0 0 250 250" style="fill:#202020; color:#fff; position: absolute; top: 0; border: 0; right: 0;" aria-hidden="true">
+		<title>View restic on GitHub</title>
+		<path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
+		<path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path>
+		<path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path>
+	</svg>
 </a>
+<style>
+	.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}
+</style>
+
   </body>
 </html>

--- a/public/blog/2015-09-12/restic-foundation1-cdc/index.html
+++ b/public/blog/2015-09-12/restic-foundation1-cdc/index.html
@@ -348,8 +348,18 @@ This gives us not only <em>inter-file</em> de-duplication, but also the more rel
       </div>
     </div>
 
-    <a href="https://github.com/restic/restic" class="desktop">
-	<img style="position: fixed; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/38ef81f8aca64bb9a64448d0d70f1308ef5341ab/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png">
+    
+<a href="https://github.com/restic/restic" class="github-corner desktop" aria-label="View restic on GitHub">
+	<svg width="80" height="80" viewBox="0 0 250 250" style="fill:#202020; color:#fff; position: absolute; top: 0; border: 0; right: 0;" aria-hidden="true">
+		<title>View restic on GitHub</title>
+		<path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
+		<path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path>
+		<path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path>
+	</svg>
 </a>
+<style>
+	.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}
+</style>
+
   </body>
 </html>

--- a/public/blog/2015-09-16/verifying-code-archive-integrity/index.html
+++ b/public/blog/2015-09-16/verifying-code-archive-integrity/index.html
@@ -179,8 +179,18 @@ addition a GPG signature is provided for the <code>tar.gz</code> files for each 
       </div>
     </div>
 
-    <a href="https://github.com/restic/restic" class="desktop">
-	<img style="position: fixed; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/38ef81f8aca64bb9a64448d0d70f1308ef5341ab/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png">
+    
+<a href="https://github.com/restic/restic" class="github-corner desktop" aria-label="View restic on GitHub">
+	<svg width="80" height="80" viewBox="0 0 250 250" style="fill:#202020; color:#fff; position: absolute; top: 0; border: 0; right: 0;" aria-hidden="true">
+		<title>View restic on GitHub</title>
+		<path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
+		<path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path>
+		<path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path>
+	</svg>
 </a>
+<style>
+	.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}
+</style>
+
   </body>
 </html>

--- a/public/blog/2016-02-04/CCC-Cologne-OpenChaos/index.html
+++ b/public/blog/2016-02-04/CCC-Cologne-OpenChaos/index.html
@@ -119,8 +119,18 @@ below. If you&rsquo;ve watched the talk and have a question or other feedback, p
       </div>
     </div>
 
-    <a href="https://github.com/restic/restic" class="desktop">
-	<img style="position: fixed; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/38ef81f8aca64bb9a64448d0d70f1308ef5341ab/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png">
+    
+<a href="https://github.com/restic/restic" class="github-corner desktop" aria-label="View restic on GitHub">
+	<svg width="80" height="80" viewBox="0 0 250 250" style="fill:#202020; color:#fff; position: absolute; top: 0; border: 0; right: 0;" aria-hidden="true">
+		<title>View restic on GitHub</title>
+		<path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
+		<path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path>
+		<path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path>
+	</svg>
 </a>
+<style>
+	.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}
+</style>
+
   </body>
 </html>

--- a/public/blog/2016-02-24/Documentation/index.html
+++ b/public/blog/2016-02-24/Documentation/index.html
@@ -100,7 +100,7 @@ changed. Of course you can also just view the Markdown files in a text editor,
 without any third-party software. We&rsquo;ll always try to make the documentation
 readable in plain text.</p>
 <p>Additionally we&rsquo;ve enabled the awesome
-<a href="https://readthedocs.org/">Read the Docs</a> service, which allows reading the
+<a href="https://about.readthedocs.com/">Read the Docs</a> service, which allows reading the
 documentation at <a href="https://restic.readthedocs.io/">https://restic.readthedocs.io/</a>. In the bottom left corner
 is a small menu which allows switching to a specific version of the
 documentation. The URL <a href="https://restic.readthedocs.io/en/latest/">https://restic.readthedocs.io/en/latest/</a> will always

--- a/public/blog/2016-02-24/Documentation/index.html
+++ b/public/blog/2016-02-24/Documentation/index.html
@@ -140,8 +140,18 @@ return the docs for the latest master branch.</p>
       </div>
     </div>
 
-    <a href="https://github.com/restic/restic" class="desktop">
-	<img style="position: fixed; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/38ef81f8aca64bb9a64448d0d70f1308ef5341ab/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png">
+    
+<a href="https://github.com/restic/restic" class="github-corner desktop" aria-label="View restic on GitHub">
+	<svg width="80" height="80" viewBox="0 0 250 250" style="fill:#202020; color:#fff; position: absolute; top: 0; border: 0; right: 0;" aria-hidden="true">
+		<title>View restic on GitHub</title>
+		<path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
+		<path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path>
+		<path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path>
+	</svg>
 </a>
+<style>
+	.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}
+</style>
+
   </body>
 </html>

--- a/public/blog/2016-08-05/restic-0.2.0-released/index.html
+++ b/public/blog/2016-08-05/restic-0.2.0-released/index.html
@@ -115,8 +115,18 @@ the detailed change log and released files can be found over at GitHub:
       </div>
     </div>
 
-    <a href="https://github.com/restic/restic" class="desktop">
-	<img style="position: fixed; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/38ef81f8aca64bb9a64448d0d70f1308ef5341ab/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png">
+    
+<a href="https://github.com/restic/restic" class="github-corner desktop" aria-label="View restic on GitHub">
+	<svg width="80" height="80" viewBox="0 0 250 250" style="fill:#202020; color:#fff; position: absolute; top: 0; border: 0; right: 0;" aria-hidden="true">
+		<title>View restic on GitHub</title>
+		<path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
+		<path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path>
+		<path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path>
+	</svg>
 </a>
+<style>
+	.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}
+</style>
+
   </body>
 </html>

--- a/public/blog/2016-08-22/removing-snapshots/index.html
+++ b/public/blog/2016-08-22/removing-snapshots/index.html
@@ -363,8 +363,18 @@ you notice any odd behavior or find bugs.</p>
       </div>
     </div>
 
-    <a href="https://github.com/restic/restic" class="desktop">
-	<img style="position: fixed; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/38ef81f8aca64bb9a64448d0d70f1308ef5341ab/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png">
+    
+<a href="https://github.com/restic/restic" class="github-corner desktop" aria-label="View restic on GitHub">
+	<svg width="80" height="80" viewBox="0 0 250 250" style="fill:#202020; color:#fff; position: absolute; top: 0; border: 0; right: 0;" aria-hidden="true">
+		<title>View restic on GitHub</title>
+		<path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
+		<path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path>
+		<path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path>
+	</svg>
 </a>
+<style>
+	.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}
+</style>
+
   </body>
 </html>

--- a/public/blog/2016-10-01/restic-0.3.0-released/index.html
+++ b/public/blog/2016-10-01/restic-0.3.0-released/index.html
@@ -115,8 +115,18 @@
       </div>
     </div>
 
-    <a href="https://github.com/restic/restic" class="desktop">
-	<img style="position: fixed; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/38ef81f8aca64bb9a64448d0d70f1308ef5341ab/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png">
+    
+<a href="https://github.com/restic/restic" class="github-corner desktop" aria-label="View restic on GitHub">
+	<svg width="80" height="80" viewBox="0 0 250 250" style="fill:#202020; color:#fff; position: absolute; top: 0; border: 0; right: 0;" aria-hidden="true">
+		<title>View restic on GitHub</title>
+		<path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
+		<path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path>
+		<path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path>
+	</svg>
 </a>
+<style>
+	.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}
+</style>
+
   </body>
 </html>

--- a/public/blog/2016-12-13/restic-0.3.1-released/index.html
+++ b/public/blog/2016-12-13/restic-0.3.1-released/index.html
@@ -114,8 +114,18 @@
       </div>
     </div>
 
-    <a href="https://github.com/restic/restic" class="desktop">
-	<img style="position: fixed; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/38ef81f8aca64bb9a64448d0d70f1308ef5341ab/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png">
+    
+<a href="https://github.com/restic/restic" class="github-corner desktop" aria-label="View restic on GitHub">
+	<svg width="80" height="80" viewBox="0 0 250 250" style="fill:#202020; color:#fff; position: absolute; top: 0; border: 0; right: 0;" aria-hidden="true">
+		<title>View restic on GitHub</title>
+		<path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
+		<path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path>
+		<path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path>
+	</svg>
 </a>
+<style>
+	.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}
+</style>
+
   </body>
 </html>

--- a/public/blog/2016-12-18/restic-0.3.2-released/index.html
+++ b/public/blog/2016-12-18/restic-0.3.2-released/index.html
@@ -114,8 +114,18 @@
       </div>
     </div>
 
-    <a href="https://github.com/restic/restic" class="desktop">
-	<img style="position: fixed; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/38ef81f8aca64bb9a64448d0d70f1308ef5341ab/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png">
+    
+<a href="https://github.com/restic/restic" class="github-corner desktop" aria-label="View restic on GitHub">
+	<svg width="80" height="80" viewBox="0 0 250 250" style="fill:#202020; color:#fff; position: absolute; top: 0; border: 0; right: 0;" aria-hidden="true">
+		<title>View restic on GitHub</title>
+		<path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
+		<path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path>
+		<path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path>
+	</svg>
 </a>
+<style>
+	.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}
+</style>
+
   </body>
 </html>

--- a/public/blog/2017-01-08/restic-0.3.3-released/index.html
+++ b/public/blog/2017-01-08/restic-0.3.3-released/index.html
@@ -115,8 +115,18 @@ A few days ago on 2 January 2017, that package entered the <code>testing</code> 
       </div>
     </div>
 
-    <a href="https://github.com/restic/restic" class="desktop">
-	<img style="position: fixed; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/38ef81f8aca64bb9a64448d0d70f1308ef5341ab/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png">
+    
+<a href="https://github.com/restic/restic" class="github-corner desktop" aria-label="View restic on GitHub">
+	<svg width="80" height="80" viewBox="0 0 250 250" style="fill:#202020; color:#fff; position: absolute; top: 0; border: 0; right: 0;" aria-hidden="true">
+		<title>View restic on GitHub</title>
+		<path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
+		<path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path>
+		<path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path>
+	</svg>
 </a>
+<style>
+	.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}
+</style>
+
   </body>
 </html>

--- a/public/blog/2017-02-02/FOSDEM-2017-Brussels/index.html
+++ b/public/blog/2017-02-02/FOSDEM-2017-Brussels/index.html
@@ -115,8 +115,18 @@ features a room on Sunday (5 February 2017) dedicated to Go development: <a href
       </div>
     </div>
 
-    <a href="https://github.com/restic/restic" class="desktop">
-	<img style="position: fixed; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/38ef81f8aca64bb9a64448d0d70f1308ef5341ab/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png">
+    
+<a href="https://github.com/restic/restic" class="github-corner desktop" aria-label="View restic on GitHub">
+	<svg width="80" height="80" viewBox="0 0 250 250" style="fill:#202020; color:#fff; position: absolute; top: 0; border: 0; right: 0;" aria-hidden="true">
+		<title>View restic on GitHub</title>
+		<path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
+		<path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path>
+		<path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path>
+	</svg>
 </a>
+<style>
+	.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}
+</style>
+
   </body>
 </html>

--- a/public/blog/2017-02-02/restic-0.4.0-released/index.html
+++ b/public/blog/2017-02-02/restic-0.4.0-released/index.html
@@ -113,8 +113,18 @@
       </div>
     </div>
 
-    <a href="https://github.com/restic/restic" class="desktop">
-	<img style="position: fixed; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/38ef81f8aca64bb9a64448d0d70f1308ef5341ab/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png">
+    
+<a href="https://github.com/restic/restic" class="github-corner desktop" aria-label="View restic on GitHub">
+	<svg width="80" height="80" viewBox="0 0 250 250" style="fill:#202020; color:#fff; position: absolute; top: 0; border: 0; right: 0;" aria-hidden="true">
+		<title>View restic on GitHub</title>
+		<path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
+		<path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path>
+		<path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path>
+	</svg>
 </a>
+<style>
+	.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}
+</style>
+
   </body>
 </html>

--- a/public/blog/2017-03-11/restic-0.5.0-released/index.html
+++ b/public/blog/2017-03-11/restic-0.5.0-released/index.html
@@ -122,8 +122,18 @@ released binaries have been compiled with Go 1.8.</p>
       </div>
     </div>
 
-    <a href="https://github.com/restic/restic" class="desktop">
-	<img style="position: fixed; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/38ef81f8aca64bb9a64448d0d70f1308ef5341ab/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png">
+    
+<a href="https://github.com/restic/restic" class="github-corner desktop" aria-label="View restic on GitHub">
+	<svg width="80" height="80" viewBox="0 0 250 250" style="fill:#202020; color:#fff; position: absolute; top: 0; border: 0; right: 0;" aria-hidden="true">
+		<title>View restic on GitHub</title>
+		<path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
+		<path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path>
+		<path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path>
+	</svg>
 </a>
+<style>
+	.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}
+</style>
+
   </body>
 </html>

--- a/public/blog/2017-05-25/restic-0.6.0-rc.1-released/index.html
+++ b/public/blog/2017-05-25/restic-0.6.0-rc.1-released/index.html
@@ -122,8 +122,18 @@ As always, thanks for <a href="https://github.com/restic/restic/issues/new">repo
       </div>
     </div>
 
-    <a href="https://github.com/restic/restic" class="desktop">
-	<img style="position: fixed; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/38ef81f8aca64bb9a64448d0d70f1308ef5341ab/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png">
+    
+<a href="https://github.com/restic/restic" class="github-corner desktop" aria-label="View restic on GitHub">
+	<svg width="80" height="80" viewBox="0 0 250 250" style="fill:#202020; color:#fff; position: absolute; top: 0; border: 0; right: 0;" aria-hidden="true">
+		<title>View restic on GitHub</title>
+		<path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
+		<path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path>
+		<path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path>
+	</svg>
 </a>
+<style>
+	.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}
+</style>
+
   </body>
 </html>

--- a/public/blog/2017-05-29/restic-0.6.0-released/index.html
+++ b/public/blog/2017-05-29/restic-0.6.0-released/index.html
@@ -122,8 +122,18 @@ As always, thanks for <a href="https://github.com/restic/restic/issues/new">repo
       </div>
     </div>
 
-    <a href="https://github.com/restic/restic" class="desktop">
-	<img style="position: fixed; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/38ef81f8aca64bb9a64448d0d70f1308ef5341ab/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png">
+    
+<a href="https://github.com/restic/restic" class="github-corner desktop" aria-label="View restic on GitHub">
+	<svg width="80" height="80" viewBox="0 0 250 250" style="fill:#202020; color:#fff; position: absolute; top: 0; border: 0; right: 0;" aria-hidden="true">
+		<title>View restic on GitHub</title>
+		<path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
+		<path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path>
+		<path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path>
+	</svg>
 </a>
+<style>
+	.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}
+</style>
+
   </body>
 </html>

--- a/public/blog/2017-05-29/restic-0.6.1-released/index.html
+++ b/public/blog/2017-05-29/restic-0.6.1-released/index.html
@@ -142,8 +142,18 @@ the binary. This is the first step in enabling reproducible builds.
       </div>
     </div>
 
-    <a href="https://github.com/restic/restic" class="desktop">
-	<img style="position: fixed; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/38ef81f8aca64bb9a64448d0d70f1308ef5341ab/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png">
+    
+<a href="https://github.com/restic/restic" class="github-corner desktop" aria-label="View restic on GitHub">
+	<svg width="80" height="80" viewBox="0 0 250 250" style="fill:#202020; color:#fff; position: absolute; top: 0; border: 0; right: 0;" aria-hidden="true">
+		<title>View restic on GitHub</title>
+		<path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
+		<path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path>
+		<path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path>
+	</svg>
 </a>
+<style>
+	.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}
+</style>
+
   </body>
 </html>

--- a/public/blog/2017-06-01/restic-on-gotime/index.html
+++ b/public/blog/2017-06-01/restic-on-gotime/index.html
@@ -114,8 +114,18 @@
       </div>
     </div>
 
-    <a href="https://github.com/restic/restic" class="desktop">
-	<img style="position: fixed; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/38ef81f8aca64bb9a64448d0d70f1308ef5341ab/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png">
+    
+<a href="https://github.com/restic/restic" class="github-corner desktop" aria-label="View restic on GitHub">
+	<svg width="80" height="80" viewBox="0 0 250 250" style="fill:#202020; color:#fff; position: absolute; top: 0; border: 0; right: 0;" aria-hidden="true">
+		<title>View restic on GitHub</title>
+		<path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
+		<path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path>
+		<path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path>
+	</svg>
 </a>
+<style>
+	.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}
+</style>
+
   </body>
 </html>

--- a/public/blog/2017-07-01/restic-0.7.0-released/index.html
+++ b/public/blog/2017-07-01/restic-0.7.0-released/index.html
@@ -180,8 +180,18 @@ returns an error message.
       </div>
     </div>
 
-    <a href="https://github.com/restic/restic" class="desktop">
-	<img style="position: fixed; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/38ef81f8aca64bb9a64448d0d70f1308ef5341ab/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png">
+    
+<a href="https://github.com/restic/restic" class="github-corner desktop" aria-label="View restic on GitHub">
+	<svg width="80" height="80" viewBox="0 0 250 250" style="fill:#202020; color:#fff; position: absolute; top: 0; border: 0; right: 0;" aria-hidden="true">
+		<title>View restic on GitHub</title>
+		<path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
+		<path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path>
+		<path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path>
+	</svg>
 </a>
+<style>
+	.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}
+</style>
+
   </body>
 </html>

--- a/public/blog/2017-07-21/FrOSCon-Bonn/index.html
+++ b/public/blog/2017-07-21/FrOSCon-Bonn/index.html
@@ -112,8 +112,18 @@
       </div>
     </div>
 
-    <a href="https://github.com/restic/restic" class="desktop">
-	<img style="position: fixed; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/38ef81f8aca64bb9a64448d0d70f1308ef5341ab/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png">
+    
+<a href="https://github.com/restic/restic" class="github-corner desktop" aria-label="View restic on GitHub">
+	<svg width="80" height="80" viewBox="0 0 250 250" style="fill:#202020; color:#fff; position: absolute; top: 0; border: 0; right: 0;" aria-hidden="true">
+		<title>View restic on GitHub</title>
+		<path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
+		<path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path>
+		<path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path>
+	</svg>
 </a>
+<style>
+	.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}
+</style>
+
   </body>
 </html>

--- a/public/blog/2017-07-22/restic-0.7.1-released/index.html
+++ b/public/blog/2017-07-22/restic-0.7.1-released/index.html
@@ -143,8 +143,18 @@ As always, thanks for <a href="https://github.com/restic/restic/issues/new">repo
       </div>
     </div>
 
-    <a href="https://github.com/restic/restic" class="desktop">
-	<img style="position: fixed; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/38ef81f8aca64bb9a64448d0d70f1308ef5341ab/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png">
+    
+<a href="https://github.com/restic/restic" class="github-corner desktop" aria-label="View restic on GitHub">
+	<svg width="80" height="80" viewBox="0 0 250 250" style="fill:#202020; color:#fff; position: absolute; top: 0; border: 0; right: 0;" aria-hidden="true">
+		<title>View restic on GitHub</title>
+		<path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
+		<path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path>
+		<path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path>
+	</svg>
 </a>
+<style>
+	.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}
+</style>
+
   </body>
 </html>

--- a/public/blog/2017-07-25/please-upgrade-to-0.7.1/index.html
+++ b/public/blog/2017-07-25/please-upgrade-to-0.7.1/index.html
@@ -239,8 +239,18 @@ and finally <code>check</code> to see if there&rsquo;s any error.</p>
       </div>
     </div>
 
-    <a href="https://github.com/restic/restic" class="desktop">
-	<img style="position: fixed; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/38ef81f8aca64bb9a64448d0d70f1308ef5341ab/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png">
+    
+<a href="https://github.com/restic/restic" class="github-corner desktop" aria-label="View restic on GitHub">
+	<svg width="80" height="80" viewBox="0 0 250 250" style="fill:#202020; color:#fff; position: absolute; top: 0; border: 0; right: 0;" aria-hidden="true">
+		<title>View restic on GitHub</title>
+		<path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
+		<path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path>
+		<path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path>
+	</svg>
 </a>
+<style>
+	.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}
+</style>
+
   </body>
 </html>

--- a/public/blog/2017-08-11/discourse-forum/index.html
+++ b/public/blog/2017-08-11/discourse-forum/index.html
@@ -113,8 +113,18 @@
       </div>
     </div>
 
-    <a href="https://github.com/restic/restic" class="desktop">
-	<img style="position: fixed; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/38ef81f8aca64bb9a64448d0d70f1308ef5341ab/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png">
+    
+<a href="https://github.com/restic/restic" class="github-corner desktop" aria-label="View restic on GitHub">
+	<svg width="80" height="80" viewBox="0 0 250 250" style="fill:#202020; color:#fff; position: absolute; top: 0; border: 0; right: 0;" aria-hidden="true">
+		<title>View restic on GitHub</title>
+		<path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
+		<path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path>
+		<path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path>
+	</svg>
 </a>
+<style>
+	.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}
+</style>
+
   </body>
 </html>

--- a/public/blog/2017-08-14/FrOSCon-Bonn-Details/index.html
+++ b/public/blog/2017-08-14/FrOSCon-Bonn-Details/index.html
@@ -113,8 +113,18 @@
       </div>
     </div>
 
-    <a href="https://github.com/restic/restic" class="desktop">
-	<img style="position: fixed; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/38ef81f8aca64bb9a64448d0d70f1308ef5341ab/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png">
+    
+<a href="https://github.com/restic/restic" class="github-corner desktop" aria-label="View restic on GitHub">
+	<svg width="80" height="80" viewBox="0 0 250 250" style="fill:#202020; color:#fff; position: absolute; top: 0; border: 0; right: 0;" aria-hidden="true">
+		<title>View restic on GitHub</title>
+		<path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
+		<path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path>
+		<path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path>
+	</svg>
 </a>
+<style>
+	.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}
+</style>
+
   </body>
 </html>

--- a/public/blog/2017-09-13/restic-0.7.2-released/index.html
+++ b/public/blog/2017-09-13/restic-0.7.2-released/index.html
@@ -204,8 +204,18 @@ As always, thanks for <a href="https://github.com/restic/restic/issues/new">repo
       </div>
     </div>
 
-    <a href="https://github.com/restic/restic" class="desktop">
-	<img style="position: fixed; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/38ef81f8aca64bb9a64448d0d70f1308ef5341ab/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png">
+    
+<a href="https://github.com/restic/restic" class="github-corner desktop" aria-label="View restic on GitHub">
+	<svg width="80" height="80" viewBox="0 0 250 250" style="fill:#202020; color:#fff; position: absolute; top: 0; border: 0; right: 0;" aria-hidden="true">
+		<title>View restic on GitHub</title>
+		<path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
+		<path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path>
+		<path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path>
+	</svg>
 </a>
+<style>
+	.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}
+</style>
+
   </body>
 </html>

--- a/public/blog/2017-09-20/restic-0.7.3-released/index.html
+++ b/public/blog/2017-09-20/restic-0.7.3-released/index.html
@@ -120,8 +120,18 @@ As always, thanks for <a href="https://github.com/restic/restic/issues/new">repo
       </div>
     </div>
 
-    <a href="https://github.com/restic/restic" class="desktop">
-	<img style="position: fixed; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/38ef81f8aca64bb9a64448d0d70f1308ef5341ab/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png">
+    
+<a href="https://github.com/restic/restic" class="github-corner desktop" aria-label="View restic on GitHub">
+	<svg width="80" height="80" viewBox="0 0 250 250" style="fill:#202020; color:#fff; position: absolute; top: 0; border: 0; right: 0;" aria-hidden="true">
+		<title>View restic on GitHub</title>
+		<path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
+		<path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path>
+		<path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path>
+	</svg>
 </a>
+<style>
+	.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}
+</style>
+
   </body>
 </html>

--- a/public/blog/2017-11-25/upcoming-changes-to-s3/index.html
+++ b/public/blog/2017-11-25/upcoming-changes-to-s3/index.html
@@ -129,8 +129,18 @@ s3:s3.amazonaws.com/backup-servers
       </div>
     </div>
 
-    <a href="https://github.com/restic/restic" class="desktop">
-	<img style="position: fixed; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/38ef81f8aca64bb9a64448d0d70f1308ef5341ab/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png">
+    
+<a href="https://github.com/restic/restic" class="github-corner desktop" aria-label="View restic on GitHub">
+	<svg width="80" height="80" viewBox="0 0 250 250" style="fill:#202020; color:#fff; position: absolute; top: 0; border: 0; right: 0;" aria-hidden="true">
+		<title>View restic on GitHub</title>
+		<path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
+		<path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path>
+		<path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path>
+	</svg>
 </a>
+<style>
+	.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}
+</style>
+
   </body>
 </html>

--- a/public/blog/2017-11-26/restic-0.8.0-released/index.html
+++ b/public/blog/2017-11-26/restic-0.8.0-released/index.html
@@ -122,8 +122,18 @@
       </div>
     </div>
 
-    <a href="https://github.com/restic/restic" class="desktop">
-	<img style="position: fixed; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/38ef81f8aca64bb9a64448d0d70f1308ef5341ab/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png">
+    
+<a href="https://github.com/restic/restic" class="github-corner desktop" aria-label="View restic on GitHub">
+	<svg width="80" height="80" viewBox="0 0 250 250" style="fill:#202020; color:#fff; position: absolute; top: 0; border: 0; right: 0;" aria-hidden="true">
+		<title>View restic on GitHub</title>
+		<path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
+		<path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path>
+		<path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path>
+	</svg>
 </a>
+<style>
+	.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}
+</style>
+
   </body>
 </html>

--- a/public/blog/2017-12-27/restic-0.8.1-released/index.html
+++ b/public/blog/2017-12-27/restic-0.8.1-released/index.html
@@ -113,8 +113,18 @@
       </div>
     </div>
 
-    <a href="https://github.com/restic/restic" class="desktop">
-	<img style="position: fixed; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/38ef81f8aca64bb9a64448d0d70f1308ef5341ab/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png">
+    
+<a href="https://github.com/restic/restic" class="github-corner desktop" aria-label="View restic on GitHub">
+	<svg width="80" height="80" viewBox="0 0 250 250" style="fill:#202020; color:#fff; position: absolute; top: 0; border: 0; right: 0;" aria-hidden="true">
+		<title>View restic on GitHub</title>
+		<path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
+		<path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path>
+		<path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path>
+	</svg>
 </a>
+<style>
+	.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}
+</style>
+
   </body>
 </html>

--- a/public/blog/2018-01-01/moving-domain/index.html
+++ b/public/blog/2018-01-01/moving-domain/index.html
@@ -122,8 +122,18 @@ so you don&rsquo;t miss out on any new posts! :)</p>
       </div>
     </div>
 
-    <a href="https://github.com/restic/restic" class="desktop">
-	<img style="position: fixed; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/38ef81f8aca64bb9a64448d0d70f1308ef5341ab/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png">
+    
+<a href="https://github.com/restic/restic" class="github-corner desktop" aria-label="View restic on GitHub">
+	<svg width="80" height="80" viewBox="0 0 250 250" style="fill:#202020; color:#fff; position: absolute; top: 0; border: 0; right: 0;" aria-hidden="true">
+		<title>View restic on GitHub</title>
+		<path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
+		<path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path>
+		<path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path>
+	</svg>
 </a>
+<style>
+	.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}
+</style>
+
   </body>
 </html>

--- a/public/blog/2018-02-17/restic-0.8.2-released/index.html
+++ b/public/blog/2018-02-17/restic-0.8.2-released/index.html
@@ -113,8 +113,18 @@
       </div>
     </div>
 
-    <a href="https://github.com/restic/restic" class="desktop">
-	<img style="position: fixed; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/38ef81f8aca64bb9a64448d0d70f1308ef5341ab/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png">
+    
+<a href="https://github.com/restic/restic" class="github-corner desktop" aria-label="View restic on GitHub">
+	<svg width="80" height="80" viewBox="0 0 250 250" style="fill:#202020; color:#fff; position: absolute; top: 0; border: 0; right: 0;" aria-hidden="true">
+		<title>View restic on GitHub</title>
+		<path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
+		<path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path>
+		<path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path>
+	</svg>
 </a>
+<style>
+	.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}
+</style>
+
   </body>
 </html>

--- a/public/blog/2018-02-26/restic-0.8.3-released/index.html
+++ b/public/blog/2018-02-26/restic-0.8.3-released/index.html
@@ -113,8 +113,18 @@
       </div>
     </div>
 
-    <a href="https://github.com/restic/restic" class="desktop">
-	<img style="position: fixed; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/38ef81f8aca64bb9a64448d0d70f1308ef5341ab/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png">
+    
+<a href="https://github.com/restic/restic" class="github-corner desktop" aria-label="View restic on GitHub">
+	<svg width="80" height="80" viewBox="0 0 250 250" style="fill:#202020; color:#fff; position: absolute; top: 0; border: 0; right: 0;" aria-hidden="true">
+		<title>View restic on GitHub</title>
+		<path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
+		<path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path>
+		<path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path>
+	</svg>
 </a>
+<style>
+	.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}
+</style>
+
   </body>
 </html>

--- a/public/blog/2018-04-01/rclone-backend/index.html
+++ b/public/blog/2018-04-01/rclone-backend/index.html
@@ -140,8 +140,18 @@ created restic repository 7905a088a0 at rclone:b2prod:yggdrasil/prod-serverA
       </div>
     </div>
 
-    <a href="https://github.com/restic/restic" class="desktop">
-	<img style="position: fixed; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/38ef81f8aca64bb9a64448d0d70f1308ef5341ab/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png">
+    
+<a href="https://github.com/restic/restic" class="github-corner desktop" aria-label="View restic on GitHub">
+	<svg width="80" height="80" viewBox="0 0 250 250" style="fill:#202020; color:#fff; position: absolute; top: 0; border: 0; right: 0;" aria-hidden="true">
+		<title>View restic on GitHub</title>
+		<path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
+		<path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path>
+		<path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path>
+	</svg>
 </a>
+<style>
+	.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}
+</style>
+
   </body>
 </html>

--- a/public/blog/2018-04-06/restic-turns-four/index.html
+++ b/public/blog/2018-04-06/restic-turns-four/index.html
@@ -118,8 +118,18 @@
       </div>
     </div>
 
-    <a href="https://github.com/restic/restic" class="desktop">
-	<img style="position: fixed; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/38ef81f8aca64bb9a64448d0d70f1308ef5341ab/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png">
+    
+<a href="https://github.com/restic/restic" class="github-corner desktop" aria-label="View restic on GitHub">
+	<svg width="80" height="80" viewBox="0 0 250 250" style="fill:#202020; color:#fff; position: absolute; top: 0; border: 0; right: 0;" aria-hidden="true">
+		<title>View restic on GitHub</title>
+		<path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
+		<path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path>
+		<path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path>
+	</svg>
 </a>
+<style>
+	.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}
+</style>
+
   </body>
 </html>

--- a/public/blog/2018-05-21/restic-0.9.0-released/index.html
+++ b/public/blog/2018-05-21/restic-0.9.0-released/index.html
@@ -113,8 +113,18 @@
       </div>
     </div>
 
-    <a href="https://github.com/restic/restic" class="desktop">
-	<img style="position: fixed; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/38ef81f8aca64bb9a64448d0d70f1308ef5341ab/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png">
+    
+<a href="https://github.com/restic/restic" class="github-corner desktop" aria-label="View restic on GitHub">
+	<svg width="80" height="80" viewBox="0 0 250 250" style="fill:#202020; color:#fff; position: absolute; top: 0; border: 0; right: 0;" aria-hidden="true">
+		<title>View restic on GitHub</title>
+		<path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
+		<path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path>
+		<path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path>
+	</svg>
 </a>
+<style>
+	.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}
+</style>
+
   </body>
 </html>

--- a/public/blog/2018-06-10/restic-0.9.1-released/index.html
+++ b/public/blog/2018-06-10/restic-0.9.1-released/index.html
@@ -113,8 +113,18 @@
       </div>
     </div>
 
-    <a href="https://github.com/restic/restic" class="desktop">
-	<img style="position: fixed; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/38ef81f8aca64bb9a64448d0d70f1308ef5341ab/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png">
+    
+<a href="https://github.com/restic/restic" class="github-corner desktop" aria-label="View restic on GitHub">
+	<svg width="80" height="80" viewBox="0 0 250 250" style="fill:#202020; color:#fff; position: absolute; top: 0; border: 0; right: 0;" aria-hidden="true">
+		<title>View restic on GitHub</title>
+		<path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
+		<path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path>
+		<path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path>
+	</svg>
 </a>
+<style>
+	.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}
+</style>
+
   </body>
 </html>

--- a/public/blog/2018-08-06/restic-0.9.2-released/index.html
+++ b/public/blog/2018-08-06/restic-0.9.2-released/index.html
@@ -113,8 +113,18 @@
       </div>
     </div>
 
-    <a href="https://github.com/restic/restic" class="desktop">
-	<img style="position: fixed; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/38ef81f8aca64bb9a64448d0d70f1308ef5341ab/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png">
+    
+<a href="https://github.com/restic/restic" class="github-corner desktop" aria-label="View restic on GitHub">
+	<svg width="80" height="80" viewBox="0 0 250 250" style="fill:#202020; color:#fff; position: absolute; top: 0; border: 0; right: 0;" aria-hidden="true">
+		<title>View restic on GitHub</title>
+		<path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
+		<path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path>
+		<path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path>
+	</svg>
 </a>
+<style>
+	.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}
+</style>
+
   </body>
 </html>

--- a/public/blog/2018-09-02/travis-build-cache/index.html
+++ b/public/blog/2018-09-02/travis-build-cache/index.html
@@ -191,8 +191,18 @@ forum</a>)!</p>
       </div>
     </div>
 
-    <a href="https://github.com/restic/restic" class="desktop">
-	<img style="position: fixed; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/38ef81f8aca64bb9a64448d0d70f1308ef5341ab/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png">
+    
+<a href="https://github.com/restic/restic" class="github-corner desktop" aria-label="View restic on GitHub">
+	<svg width="80" height="80" viewBox="0 0 250 250" style="fill:#202020; color:#fff; position: absolute; top: 0; border: 0; right: 0;" aria-hidden="true">
+		<title>View restic on GitHub</title>
+		<path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
+		<path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path>
+		<path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path>
+	</svg>
 </a>
+<style>
+	.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}
+</style>
+
   </body>
 </html>

--- a/public/blog/2018-09-09/GitHub-issue-templates/index.html
+++ b/public/blog/2018-09-09/GitHub-issue-templates/index.html
@@ -182,8 +182,18 @@ linked below this article!</p>
       </div>
     </div>
 
-    <a href="https://github.com/restic/restic" class="desktop">
-	<img style="position: fixed; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/38ef81f8aca64bb9a64448d0d70f1308ef5341ab/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png">
+    
+<a href="https://github.com/restic/restic" class="github-corner desktop" aria-label="View restic on GitHub">
+	<svg width="80" height="80" viewBox="0 0 250 250" style="fill:#202020; color:#fff; position: absolute; top: 0; border: 0; right: 0;" aria-hidden="true">
+		<title>View restic on GitHub</title>
+		<path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
+		<path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path>
+		<path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path>
+	</svg>
 </a>
+<style>
+	.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}
+</style>
+
   </body>
 </html>

--- a/public/blog/2018-10-13/restic-0.9.3-released/index.html
+++ b/public/blog/2018-10-13/restic-0.9.3-released/index.html
@@ -113,8 +113,18 @@
       </div>
     </div>
 
-    <a href="https://github.com/restic/restic" class="desktop">
-	<img style="position: fixed; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/38ef81f8aca64bb9a64448d0d70f1308ef5341ab/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png">
+    
+<a href="https://github.com/restic/restic" class="github-corner desktop" aria-label="View restic on GitHub">
+	<svg width="80" height="80" viewBox="0 0 250 250" style="fill:#202020; color:#fff; position: absolute; top: 0; border: 0; right: 0;" aria-hidden="true">
+		<title>View restic on GitHub</title>
+		<path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
+		<path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path>
+		<path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path>
+	</svg>
 </a>
+<style>
+	.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}
+</style>
+
   </body>
 </html>

--- a/public/blog/2019-01-01/new-infrastructure/index.html
+++ b/public/blog/2019-01-01/new-infrastructure/index.html
@@ -114,8 +114,18 @@
       </div>
     </div>
 
-    <a href="https://github.com/restic/restic" class="desktop">
-	<img style="position: fixed; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/38ef81f8aca64bb9a64448d0d70f1308ef5341ab/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png">
+    
+<a href="https://github.com/restic/restic" class="github-corner desktop" aria-label="View restic on GitHub">
+	<svg width="80" height="80" viewBox="0 0 250 250" style="fill:#202020; color:#fff; position: absolute; top: 0; border: 0; right: 0;" aria-hidden="true">
+		<title>View restic on GitHub</title>
+		<path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
+		<path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path>
+		<path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path>
+	</svg>
 </a>
+<style>
+	.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}
+</style>
+
   </body>
 </html>

--- a/public/blog/2019-01-06/restic-0.9.4-released/index.html
+++ b/public/blog/2019-01-06/restic-0.9.4-released/index.html
@@ -117,8 +117,18 @@
       </div>
     </div>
 
-    <a href="https://github.com/restic/restic" class="desktop">
-	<img style="position: fixed; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/38ef81f8aca64bb9a64448d0d70f1308ef5341ab/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png">
+    
+<a href="https://github.com/restic/restic" class="github-corner desktop" aria-label="View restic on GitHub">
+	<svg width="80" height="80" viewBox="0 0 250 250" style="fill:#202020; color:#fff; position: absolute; top: 0; border: 0; right: 0;" aria-hidden="true">
+		<title>View restic on GitHub</title>
+		<path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
+		<path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path>
+		<path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path>
+	</svg>
 </a>
+<style>
+	.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}
+</style>
+
   </body>
 </html>

--- a/public/blog/2019-04-23/restic-0.9.5-released/index.html
+++ b/public/blog/2019-04-23/restic-0.9.5-released/index.html
@@ -113,8 +113,18 @@
       </div>
     </div>
 
-    <a href="https://github.com/restic/restic" class="desktop">
-	<img style="position: fixed; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/38ef81f8aca64bb9a64448d0d70f1308ef5341ab/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png">
+    
+<a href="https://github.com/restic/restic" class="github-corner desktop" aria-label="View restic on GitHub">
+	<svg width="80" height="80" viewBox="0 0 250 250" style="fill:#202020; color:#fff; position: absolute; top: 0; border: 0; right: 0;" aria-hidden="true">
+		<title>View restic on GitHub</title>
+		<path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
+		<path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path>
+		<path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path>
+	</svg>
 </a>
+<style>
+	.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}
+</style>
+
   </body>
 </html>

--- a/public/blog/2019-11-22/restic-0.9.6-released/index.html
+++ b/public/blog/2019-11-22/restic-0.9.6-released/index.html
@@ -113,8 +113,18 @@
       </div>
     </div>
 
-    <a href="https://github.com/restic/restic" class="desktop">
-	<img style="position: fixed; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/38ef81f8aca64bb9a64448d0d70f1308ef5341ab/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png">
+    
+<a href="https://github.com/restic/restic" class="github-corner desktop" aria-label="View restic on GitHub">
+	<svg width="80" height="80" viewBox="0 0 250 250" style="fill:#202020; color:#fff; position: absolute; top: 0; border: 0; right: 0;" aria-hidden="true">
+		<title>View restic on GitHub</title>
+		<path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
+		<path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path>
+		<path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path>
+	</svg>
 </a>
+<style>
+	.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}
+</style>
+
   </body>
 </html>

--- a/public/blog/2020-09-13/rest-server-0.10.0-released/index.html
+++ b/public/blog/2020-09-13/rest-server-0.10.0-released/index.html
@@ -116,8 +116,18 @@
       </div>
     </div>
 
-    <a href="https://github.com/restic/restic" class="desktop">
-	<img style="position: fixed; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/38ef81f8aca64bb9a64448d0d70f1308ef5341ab/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png">
+    
+<a href="https://github.com/restic/restic" class="github-corner desktop" aria-label="View restic on GitHub">
+	<svg width="80" height="80" viewBox="0 0 250 250" style="fill:#202020; color:#fff; position: absolute; top: 0; border: 0; right: 0;" aria-hidden="true">
+		<title>View restic on GitHub</title>
+		<path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
+		<path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path>
+		<path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path>
+	</svg>
 </a>
+<style>
+	.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}
+</style>
+
   </body>
 </html>

--- a/public/blog/2020-09-19/restic-0.10.0-released/index.html
+++ b/public/blog/2020-09-19/restic-0.10.0-released/index.html
@@ -126,8 +126,18 @@
       </div>
     </div>
 
-    <a href="https://github.com/restic/restic" class="desktop">
-	<img style="position: fixed; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/38ef81f8aca64bb9a64448d0d70f1308ef5341ab/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png">
+    
+<a href="https://github.com/restic/restic" class="github-corner desktop" aria-label="View restic on GitHub">
+	<svg width="80" height="80" viewBox="0 0 250 250" style="fill:#202020; color:#fff; position: absolute; top: 0; border: 0; right: 0;" aria-hidden="true">
+		<title>View restic on GitHub</title>
+		<path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
+		<path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path>
+		<path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path>
+	</svg>
 </a>
+<style>
+	.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}
+</style>
+
   </body>
 </html>

--- a/public/blog/2020-11-05/restic-0.11.0-released/index.html
+++ b/public/blog/2020-11-05/restic-0.11.0-released/index.html
@@ -114,8 +114,18 @@
       </div>
     </div>
 
-    <a href="https://github.com/restic/restic" class="desktop">
-	<img style="position: fixed; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/38ef81f8aca64bb9a64448d0d70f1308ef5341ab/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png">
+    
+<a href="https://github.com/restic/restic" class="github-corner desktop" aria-label="View restic on GitHub">
+	<svg width="80" height="80" viewBox="0 0 250 250" style="fill:#202020; color:#fff; position: absolute; top: 0; border: 0; right: 0;" aria-hidden="true">
+		<title>View restic on GitHub</title>
+		<path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
+		<path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path>
+		<path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path>
+	</svg>
 </a>
+<style>
+	.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}
+</style>
+
   </body>
 </html>

--- a/public/blog/2021-02-14/restic-0.12.0-released/index.html
+++ b/public/blog/2021-02-14/restic-0.12.0-released/index.html
@@ -114,8 +114,18 @@
       </div>
     </div>
 
-    <a href="https://github.com/restic/restic" class="desktop">
-	<img style="position: fixed; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/38ef81f8aca64bb9a64448d0d70f1308ef5341ab/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png">
+    
+<a href="https://github.com/restic/restic" class="github-corner desktop" aria-label="View restic on GitHub">
+	<svg width="80" height="80" viewBox="0 0 250 250" style="fill:#202020; color:#fff; position: absolute; top: 0; border: 0; right: 0;" aria-hidden="true">
+		<title>View restic on GitHub</title>
+		<path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
+		<path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path>
+		<path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path>
+	</svg>
 </a>
+<style>
+	.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}
+</style>
+
   </body>
 </html>

--- a/public/blog/2021-08-03/restic-0.12.1-released/index.html
+++ b/public/blog/2021-08-03/restic-0.12.1-released/index.html
@@ -114,8 +114,18 @@
       </div>
     </div>
 
-    <a href="https://github.com/restic/restic" class="desktop">
-	<img style="position: fixed; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/38ef81f8aca64bb9a64448d0d70f1308ef5341ab/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png">
+    
+<a href="https://github.com/restic/restic" class="github-corner desktop" aria-label="View restic on GitHub">
+	<svg width="80" height="80" viewBox="0 0 250 250" style="fill:#202020; color:#fff; position: absolute; top: 0; border: 0; right: 0;" aria-hidden="true">
+		<title>View restic on GitHub</title>
+		<path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
+		<path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path>
+		<path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path>
+	</svg>
 </a>
+<style>
+	.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}
+</style>
+
   </body>
 </html>

--- a/public/blog/2022-02-10/rest-server-0.11.0-released/index.html
+++ b/public/blog/2022-02-10/rest-server-0.11.0-released/index.html
@@ -113,8 +113,18 @@
       </div>
     </div>
 
-    <a href="https://github.com/restic/restic" class="desktop">
-	<img style="position: fixed; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/38ef81f8aca64bb9a64448d0d70f1308ef5341ab/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png">
+    
+<a href="https://github.com/restic/restic" class="github-corner desktop" aria-label="View restic on GitHub">
+	<svg width="80" height="80" viewBox="0 0 250 250" style="fill:#202020; color:#fff; position: absolute; top: 0; border: 0; right: 0;" aria-hidden="true">
+		<title>View restic on GitHub</title>
+		<path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
+		<path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path>
+		<path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path>
+	</svg>
 </a>
+<style>
+	.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}
+</style>
+
   </body>
 </html>

--- a/public/blog/2022-03-26/restic-0.13.0-released/index.html
+++ b/public/blog/2022-03-26/restic-0.13.0-released/index.html
@@ -121,8 +121,18 @@
       </div>
     </div>
 
-    <a href="https://github.com/restic/restic" class="desktop">
-	<img style="position: fixed; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/38ef81f8aca64bb9a64448d0d70f1308ef5341ab/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png">
+    
+<a href="https://github.com/restic/restic" class="github-corner desktop" aria-label="View restic on GitHub">
+	<svg width="80" height="80" viewBox="0 0 250 250" style="fill:#202020; color:#fff; position: absolute; top: 0; border: 0; right: 0;" aria-hidden="true">
+		<title>View restic on GitHub</title>
+		<path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
+		<path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path>
+		<path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path>
+	</svg>
 </a>
+<style>
+	.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}
+</style>
+
   </body>
 </html>

--- a/public/blog/2022-04-10/restic-0.13.1-released/index.html
+++ b/public/blog/2022-04-10/restic-0.13.1-released/index.html
@@ -114,8 +114,18 @@
       </div>
     </div>
 
-    <a href="https://github.com/restic/restic" class="desktop">
-	<img style="position: fixed; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/38ef81f8aca64bb9a64448d0d70f1308ef5341ab/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png">
+    
+<a href="https://github.com/restic/restic" class="github-corner desktop" aria-label="View restic on GitHub">
+	<svg width="80" height="80" viewBox="0 0 250 250" style="fill:#202020; color:#fff; position: absolute; top: 0; border: 0; right: 0;" aria-hidden="true">
+		<title>View restic on GitHub</title>
+		<path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
+		<path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path>
+		<path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path>
+	</svg>
 </a>
+<style>
+	.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}
+</style>
+
   </body>
 </html>

--- a/public/blog/2022-08-25/restic-0.14.0-released/index.html
+++ b/public/blog/2022-08-25/restic-0.14.0-released/index.html
@@ -125,8 +125,18 @@
       </div>
     </div>
 
-    <a href="https://github.com/restic/restic" class="desktop">
-	<img style="position: fixed; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/38ef81f8aca64bb9a64448d0d70f1308ef5341ab/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png">
+    
+<a href="https://github.com/restic/restic" class="github-corner desktop" aria-label="View restic on GitHub">
+	<svg width="80" height="80" viewBox="0 0 250 250" style="fill:#202020; color:#fff; position: absolute; top: 0; border: 0; right: 0;" aria-hidden="true">
+		<title>View restic on GitHub</title>
+		<path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
+		<path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path>
+		<path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path>
+	</svg>
 </a>
+<style>
+	.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}
+</style>
+
   </body>
 </html>

--- a/public/blog/2023-01-12/restic-0.15.0-released/index.html
+++ b/public/blog/2023-01-12/restic-0.15.0-released/index.html
@@ -129,8 +129,18 @@
       </div>
     </div>
 
-    <a href="https://github.com/restic/restic" class="desktop">
-	<img style="position: fixed; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/38ef81f8aca64bb9a64448d0d70f1308ef5341ab/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png">
+    
+<a href="https://github.com/restic/restic" class="github-corner desktop" aria-label="View restic on GitHub">
+	<svg width="80" height="80" viewBox="0 0 250 250" style="fill:#202020; color:#fff; position: absolute; top: 0; border: 0; right: 0;" aria-hidden="true">
+		<title>View restic on GitHub</title>
+		<path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
+		<path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path>
+		<path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path>
+	</svg>
 </a>
+<style>
+	.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}
+</style>
+
   </body>
 </html>

--- a/public/blog/2023-01-30/restic-0.15.1-released/index.html
+++ b/public/blog/2023-01-30/restic-0.15.1-released/index.html
@@ -114,8 +114,18 @@
       </div>
     </div>
 
-    <a href="https://github.com/restic/restic" class="desktop">
-	<img style="position: fixed; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/38ef81f8aca64bb9a64448d0d70f1308ef5341ab/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png">
+    
+<a href="https://github.com/restic/restic" class="github-corner desktop" aria-label="View restic on GitHub">
+	<svg width="80" height="80" viewBox="0 0 250 250" style="fill:#202020; color:#fff; position: absolute; top: 0; border: 0; right: 0;" aria-hidden="true">
+		<title>View restic on GitHub</title>
+		<path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
+		<path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path>
+		<path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path>
+	</svg>
 </a>
+<style>
+	.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}
+</style>
+
   </body>
 </html>

--- a/public/blog/2023-04-24/rest-server-0.12.0-released/index.html
+++ b/public/blog/2023-04-24/rest-server-0.12.0-released/index.html
@@ -114,8 +114,18 @@
       </div>
     </div>
 
-    <a href="https://github.com/restic/restic" class="desktop">
-	<img style="position: fixed; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/38ef81f8aca64bb9a64448d0d70f1308ef5341ab/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png">
+    
+<a href="https://github.com/restic/restic" class="github-corner desktop" aria-label="View restic on GitHub">
+	<svg width="80" height="80" viewBox="0 0 250 250" style="fill:#202020; color:#fff; position: absolute; top: 0; border: 0; right: 0;" aria-hidden="true">
+		<title>View restic on GitHub</title>
+		<path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
+		<path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path>
+		<path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path>
+	</svg>
 </a>
+<style>
+	.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}
+</style>
+
   </body>
 </html>

--- a/public/blog/2023-04-24/restic-0.15.2-released/index.html
+++ b/public/blog/2023-04-24/restic-0.15.2-released/index.html
@@ -115,8 +115,18 @@
       </div>
     </div>
 
-    <a href="https://github.com/restic/restic" class="desktop">
-	<img style="position: fixed; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/38ef81f8aca64bb9a64448d0d70f1308ef5341ab/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png">
+    
+<a href="https://github.com/restic/restic" class="github-corner desktop" aria-label="View restic on GitHub">
+	<svg width="80" height="80" viewBox="0 0 250 250" style="fill:#202020; color:#fff; position: absolute; top: 0; border: 0; right: 0;" aria-hidden="true">
+		<title>View restic on GitHub</title>
+		<path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
+		<path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path>
+		<path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path>
+	</svg>
 </a>
+<style>
+	.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}
+</style>
+
   </body>
 </html>

--- a/public/blog/2023-07-09/rest-server-0.12.1-released/index.html
+++ b/public/blog/2023-07-09/rest-server-0.12.1-released/index.html
@@ -114,8 +114,18 @@
       </div>
     </div>
 
-    <a href="https://github.com/restic/restic" class="desktop">
-	<img style="position: fixed; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/38ef81f8aca64bb9a64448d0d70f1308ef5341ab/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png">
+    
+<a href="https://github.com/restic/restic" class="github-corner desktop" aria-label="View restic on GitHub">
+	<svg width="80" height="80" viewBox="0 0 250 250" style="fill:#202020; color:#fff; position: absolute; top: 0; border: 0; right: 0;" aria-hidden="true">
+		<title>View restic on GitHub</title>
+		<path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
+		<path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path>
+		<path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path>
+	</svg>
 </a>
+<style>
+	.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}
+</style>
+
   </body>
 </html>

--- a/public/blog/2023-07-31/restic-0.16.0-released/index.html
+++ b/public/blog/2023-07-31/restic-0.16.0-released/index.html
@@ -126,8 +126,18 @@
       </div>
     </div>
 
-    <a href="https://github.com/restic/restic" class="desktop">
-	<img style="position: fixed; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/38ef81f8aca64bb9a64448d0d70f1308ef5341ab/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png">
+    
+<a href="https://github.com/restic/restic" class="github-corner desktop" aria-label="View restic on GitHub">
+	<svg width="80" height="80" viewBox="0 0 250 250" style="fill:#202020; color:#fff; position: absolute; top: 0; border: 0; right: 0;" aria-hidden="true">
+		<title>View restic on GitHub</title>
+		<path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
+		<path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path>
+		<path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path>
+	</svg>
 </a>
+<style>
+	.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}
+</style>
+
   </body>
 </html>

--- a/public/blog/2023-10-24/restic-0.16.1-released/index.html
+++ b/public/blog/2023-10-24/restic-0.16.1-released/index.html
@@ -115,8 +115,18 @@
       </div>
     </div>
 
-    <a href="https://github.com/restic/restic" class="desktop">
-	<img style="position: fixed; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/38ef81f8aca64bb9a64448d0d70f1308ef5341ab/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png">
+    
+<a href="https://github.com/restic/restic" class="github-corner desktop" aria-label="View restic on GitHub">
+	<svg width="80" height="80" viewBox="0 0 250 250" style="fill:#202020; color:#fff; position: absolute; top: 0; border: 0; right: 0;" aria-hidden="true">
+		<title>View restic on GitHub</title>
+		<path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
+		<path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path>
+		<path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path>
+	</svg>
 </a>
+<style>
+	.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}
+</style>
+
   </body>
 </html>

--- a/public/blog/2023-10-29/restic-0.16.2-released/index.html
+++ b/public/blog/2023-10-29/restic-0.16.2-released/index.html
@@ -115,8 +115,18 @@
       </div>
     </div>
 
-    <a href="https://github.com/restic/restic" class="desktop">
-	<img style="position: fixed; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/38ef81f8aca64bb9a64448d0d70f1308ef5341ab/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png">
+    
+<a href="https://github.com/restic/restic" class="github-corner desktop" aria-label="View restic on GitHub">
+	<svg width="80" height="80" viewBox="0 0 250 250" style="fill:#202020; color:#fff; position: absolute; top: 0; border: 0; right: 0;" aria-hidden="true">
+		<title>View restic on GitHub</title>
+		<path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
+		<path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path>
+		<path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path>
+	</svg>
 </a>
+<style>
+	.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}
+</style>
+
   </body>
 </html>

--- a/public/blog/index.html
+++ b/public/blog/index.html
@@ -271,8 +271,18 @@
         <a href="/blog/index.xml">RSS Feed</a>
     </div>
 
-    <a href="https://github.com/restic/restic" class="desktop">
-	<img style="position: fixed; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/38ef81f8aca64bb9a64448d0d70f1308ef5341ab/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png">
+    
+<a href="https://github.com/restic/restic" class="github-corner desktop" aria-label="View restic on GitHub">
+	<svg width="80" height="80" viewBox="0 0 250 250" style="fill:#202020; color:#fff; position: absolute; top: 0; border: 0; right: 0;" aria-hidden="true">
+		<title>View restic on GitHub</title>
+		<path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
+		<path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path>
+		<path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path>
+	</svg>
 </a>
+<style>
+	.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}
+</style>
+
   </body>
 </html>

--- a/public/blog/index.xml
+++ b/public/blog/index.xml
@@ -13,113 +13,91 @@
       <link>https://restic.net/blog/2023-10-29/restic-0.16.2-released/</link>
       <pubDate>Sun, 29 Oct 2023 00:00:00 +0200</pubDate>
       <guid>https://restic.net/blog/2023-10-29/restic-0.16.2-released/</guid>
-      <description>We are happy to announce the release of restic 0.16.2!
-This release restores support for ARMv5 which was accidentally not included in the previous one, and also fixes missing documentation on Read the Docs.
-To download the new release and to see a more detailed list of important changes, please head over to GitHub. If you already have restic (0.9.4 or later), you can use the self-update command to automatically download and verify the new release.</description>
+      <description>We are happy to announce the release of restic 0.16.2!&#xA;This release restores support for ARMv5 which was accidentally not included in the previous one, and also fixes missing documentation on Read the Docs.&#xA;To download the new release and to see a more detailed list of important changes, please head over to GitHub. If you already have restic (0.9.4 or later), you can use the self-update command to automatically download and verify the new release.</description>
     </item>
     <item>
       <title>Restic 0.16.1 Released</title>
       <link>https://restic.net/blog/2023-10-24/restic-0.16.1-released/</link>
       <pubDate>Tue, 24 Oct 2023 00:00:00 +0200</pubDate>
       <guid>https://restic.net/blog/2023-10-24/restic-0.16.1-released/</guid>
-      <description>We are happy to announce the release of restic 0.16.1!
-This release contains a few usage and cosmetic improvements, but also one bugfix for a very unlikely but still possible data corruption issue when using the max compression level. Please read the changelog for more details and information on how to verify your repository if you used max compression. Please also note that the auto compression level (which is the default) was never affected.</description>
+      <description>We are happy to announce the release of restic 0.16.1!&#xA;This release contains a few usage and cosmetic improvements, but also one bugfix for a very unlikely but still possible data corruption issue when using the max compression level. Please read the changelog for more details and information on how to verify your repository if you used max compression. Please also note that the auto compression level (which is the default) was never affected.</description>
     </item>
     <item>
       <title>Restic 0.16.0 Released</title>
       <link>https://restic.net/blog/2023-07-31/restic-0.16.0-released/</link>
       <pubDate>Mon, 31 Jul 2023 20:42:23 +0200</pubDate>
       <guid>https://restic.net/blog/2023-07-31/restic-0.16.0-released/</guid>
-      <description>We are happy to announce the release of restic 0.16.0!
-This version of restic brings up to 25% less memory usage and a lot of usability improvements, including &amp;lt;snapshot&amp;gt;:&amp;lt;subfolder&amp;gt; syntax for the diff, ls and restore commands, as well as a progress bar and JSON support for the restore command. Please see the documentation of each command for details.
-Restic now also includes a repair snapshots command, which can be used to salvage certain types of damaged repositories.</description>
+      <description>We are happy to announce the release of restic 0.16.0!&#xA;This version of restic brings up to 25% less memory usage and a lot of usability improvements, including &amp;lt;snapshot&amp;gt;:&amp;lt;subfolder&amp;gt; syntax for the diff, ls and restore commands, as well as a progress bar and JSON support for the restore command. Please see the documentation of each command for details.&#xA;Restic now also includes a repair snapshots command, which can be used to salvage certain types of damaged repositories.</description>
     </item>
     <item>
       <title>REST-server 0.12.1 released</title>
       <link>https://restic.net/blog/2023-07-09/rest-server-0.12.1-released/</link>
       <pubDate>Sun, 09 Jul 2023 18:00:00 +0200</pubDate>
       <guid>https://restic.net/blog/2023-07-09/rest-server-0.12.1-released/</guid>
-      <description>We have just released rest-server 0.12.1.
-This release includes a bugfix for fsync related warnings and allows logging to stdout using the --log - option. Please see the changelog for more specific information!
-Please let us know what you think in the forum post linked below!</description>
+      <description>We have just released rest-server 0.12.1.&#xA;This release includes a bugfix for fsync related warnings and allows logging to stdout using the --log - option. Please see the changelog for more specific information!&#xA;Please let us know what you think in the forum post linked below!</description>
     </item>
     <item>
       <title>REST-server 0.12.0 released</title>
       <link>https://restic.net/blog/2023-04-24/rest-server-0.12.0-released/</link>
       <pubDate>Mon, 24 Apr 2023 13:00:00 +0200</pubDate>
       <guid>https://restic.net/blog/2023-04-24/rest-server-0.12.0-released/</guid>
-      <description>We have just released rest-server 0.12.0.
-This release includes performance optimizations, allowing additional characters in usernames, ability to specify .htpasswd file location, as well as some macOS specific fixes and other general compatibility fixes. Please see the changelog for more specific information!
-Please let us know what you think in the forum post linked below!</description>
+      <description>We have just released rest-server 0.12.0.&#xA;This release includes performance optimizations, allowing additional characters in usernames, ability to specify .htpasswd file location, as well as some macOS specific fixes and other general compatibility fixes. Please see the changelog for more specific information!&#xA;Please let us know what you think in the forum post linked below!</description>
     </item>
     <item>
       <title>Restic 0.15.2 released</title>
       <link>https://restic.net/blog/2023-04-24/restic-0.15.2-released/</link>
       <pubDate>Mon, 24 Apr 2023 12:00:00 +0200</pubDate>
       <guid>https://restic.net/blog/2023-04-24/restic-0.15.2-released/</guid>
-      <description>We&amp;rsquo;re very pleased to announce restic 0.15.2!
-This release is primarily intended to address some minor bugs and cosmetic issues, but worth mentioning is that it is now possible to use the ap-southeast-4 region (Melbourne) with S3. Also, official restic builds for the riscv64 architecture on Linux are now available.
-To download the new release and to see a more detailed list of important changes, please head over to GitHub. If you already have restic (0.</description>
+      <description>We&amp;rsquo;re very pleased to announce restic 0.15.2!&#xA;This release is primarily intended to address some minor bugs and cosmetic issues, but worth mentioning is that it is now possible to use the ap-southeast-4 region (Melbourne) with S3. Also, official restic builds for the riscv64 architecture on Linux are now available.&#xA;To download the new release and to see a more detailed list of important changes, please head over to GitHub. If you already have restic (0.</description>
     </item>
     <item>
       <title>Restic 0.15.1 Released</title>
       <link>https://restic.net/blog/2023-01-30/restic-0.15.1-released/</link>
       <pubDate>Mon, 30 Jan 2023 00:00:00 +0100</pubDate>
       <guid>https://restic.net/blog/2023-01-30/restic-0.15.1-released/</guid>
-      <description>We&amp;rsquo;re very pleased to announce restic 0.15.1! This is just a small bugfix release, fixing some issues and cosmetic inconveniences.
-To download the new release and to see a more detailed list of important changes, please head over to GitHub. If you already have restic (0.9.4 or later), you can use the self-update command to automatically download and verify the new release.
-As always, thanks for reporting any issues you encounter!</description>
+      <description>We&amp;rsquo;re very pleased to announce restic 0.15.1! This is just a small bugfix release, fixing some issues and cosmetic inconveniences.&#xA;To download the new release and to see a more detailed list of important changes, please head over to GitHub. If you already have restic (0.9.4 or later), you can use the self-update command to automatically download and verify the new release.&#xA;As always, thanks for reporting any issues you encounter!</description>
     </item>
     <item>
       <title>Restic 0.15.0 Released</title>
       <link>https://restic.net/blog/2023-01-12/restic-0.15.0-released/</link>
       <pubDate>Thu, 12 Jan 2023 21:14:23 +0100</pubDate>
       <guid>https://restic.net/blog/2023-01-12/restic-0.15.0-released/</guid>
-      <description>We are happy to announce the release of restic 0.15.0!
-In this version, a new rewrite command has been implemented. This allows for removing unwanted data from existing snapshots, for example if you discover that some files were unintentionally backed up, such as files with sensitive content or files that take up a lot of space and don&amp;rsquo;t need to be backed up. Please see the corresponding documentation for more information and usage examples.</description>
+      <description>We are happy to announce the release of restic 0.15.0!&#xA;In this version, a new rewrite command has been implemented. This allows for removing unwanted data from existing snapshots, for example if you discover that some files were unintentionally backed up, such as files with sensitive content or files that take up a lot of space and don&amp;rsquo;t need to be backed up. Please see the corresponding documentation for more information and usage examples.</description>
     </item>
     <item>
       <title>Restic 0.14.0 Released</title>
       <link>https://restic.net/blog/2022-08-25/restic-0.14.0-released/</link>
       <pubDate>Thu, 25 Aug 2022 20:16:02 +0200</pubDate>
       <guid>https://restic.net/blog/2022-08-25/restic-0.14.0-released/</guid>
-      <description>We today happily announce the release of restic 0.14.0! \o/
-This release contains a highly anticipated feature in restic - compression! To start using it, either initialize a new repository (which defaults to repository version 2 and therefore supports compression) or upgrade your current repository. The compression level can be changed from the default auto (fast and efficient) to max or off using the --compression option (or the corresponding environment variable).</description>
+      <description>We today happily announce the release of restic 0.14.0! \o/&#xA;This release contains a highly anticipated feature in restic - compression! To start using it, either initialize a new repository (which defaults to repository version 2 and therefore supports compression) or upgrade your current repository. The compression level can be changed from the default auto (fast and efficient) to max or off using the --compression option (or the corresponding environment variable).</description>
     </item>
     <item>
       <title>Restic 0.13.1 Released</title>
       <link>https://restic.net/blog/2022-04-10/restic-0.13.1-released/</link>
       <pubDate>Sun, 10 Apr 2022 11:16:23 +0200</pubDate>
       <guid>https://restic.net/blog/2022-04-10/restic-0.13.1-released/</guid>
-      <description>We&amp;rsquo;re proud to announce that restic 0.13.1 has been released today!
-This release contains two smaller bug fixes which came up after the last release. For downloading the new release and to see a more detailed list of important changes, please head over to GitHub. If you already have restic (0.9.4 or later), you can use the self-update command to automatically download and verify the new release.
-As always, thanks for reporting any issues you encounter!</description>
+      <description>We&amp;rsquo;re proud to announce that restic 0.13.1 has been released today!&#xA;This release contains two smaller bug fixes which came up after the last release. For downloading the new release and to see a more detailed list of important changes, please head over to GitHub. If you already have restic (0.9.4 or later), you can use the self-update command to automatically download and verify the new release.&#xA;As always, thanks for reporting any issues you encounter!</description>
     </item>
     <item>
       <title>Restic 0.13.0 Released</title>
       <link>https://restic.net/blog/2022-03-26/restic-0.13.0-released/</link>
       <pubDate>Sat, 26 Mar 2022 19:47:44 +0100</pubDate>
       <guid>https://restic.net/blog/2022-03-26/restic-0.13.0-released/</guid>
-      <description>We&amp;rsquo;re proud to announce that restic 0.13.0 has been released today!
-This release contains several bug fixes and improvements worth mentioning:
-It is now possible to add negative patterns to cancel previous exclusions (e.g. --exclude &#39;/home/user/*&#39; --exclude &#39;!/home/user/.config&#39;). The backup command now has a --dry-run switch which (together with --verbose) prints the files that would be included in a backup. We have added checksums for various backends so data uploaded to a backend can be checked there.</description>
+      <description>We&amp;rsquo;re proud to announce that restic 0.13.0 has been released today!&#xA;This release contains several bug fixes and improvements worth mentioning:&#xA;It is now possible to add negative patterns to cancel previous exclusions (e.g. --exclude &#39;/home/user/*&#39; --exclude &#39;!/home/user/.config&#39;). The backup command now has a --dry-run switch which (together with --verbose) prints the files that would be included in a backup. We have added checksums for various backends so data uploaded to a backend can be checked there.</description>
     </item>
     <item>
       <title>Rest Server 0.11.0 released</title>
       <link>https://restic.net/blog/2022-02-10/rest-server-0.11.0-released/</link>
       <pubDate>Thu, 10 Feb 2022 20:23:36 +0100</pubDate>
       <guid>https://restic.net/blog/2022-02-10/rest-server-0.11.0-released/</guid>
-      <description>We have just released rest-server 0.11.0. It includes a fix for an issue where during transfer, a file could have been corrupted. The details are described in PR #142. The full changelog is included in the release.
-Please let us know what you think in the forum post linked below!</description>
+      <description>We have just released rest-server 0.11.0. It includes a fix for an issue where during transfer, a file could have been corrupted. The details are described in PR #142. The full changelog is included in the release.&#xA;Please let us know what you think in the forum post linked below!</description>
     </item>
     <item>
       <title>Restic 0.12.1 released</title>
       <link>https://restic.net/blog/2021-08-03/restic-0.12.1-released/</link>
       <pubDate>Tue, 03 Aug 2021 12:04:36 +0200</pubDate>
       <guid>https://restic.net/blog/2021-08-03/restic-0.12.1-released/</guid>
-      <description>We&amp;rsquo;re proud to announce that restic 0.12.1 has been released today! This release contains several small fixes for bugs and a few smaller enhancements.
-For downloading the new release and to see a more detailed list of important changes, please head over to GitHub. If you already have restic (0.9.4 or later), you can use the self-update command to automatically download and verify the new release.
-As always, thanks for reporting any issues you encounter!</description>
+      <description>We&amp;rsquo;re proud to announce that restic 0.12.1 has been released today! This release contains several small fixes for bugs and a few smaller enhancements.&#xA;For downloading the new release and to see a more detailed list of important changes, please head over to GitHub. If you already have restic (0.9.4 or later), you can use the self-update command to automatically download and verify the new release.&#xA;As always, thanks for reporting any issues you encounter!</description>
     </item>
     <item>
       <title>Restic 0.12.0 released</title>
@@ -133,66 +111,56 @@ As always, thanks for reporting any issues you encounter!</description>
       <link>https://restic.net/blog/2020-11-05/restic-0.11.0-released/</link>
       <pubDate>Thu, 05 Nov 2020 10:00:51 +0100</pubDate>
       <guid>https://restic.net/blog/2020-11-05/restic-0.11.0-released/</guid>
-      <description>Restic 0.11.0 was released today! For downloading the new release and to see a more detailed list of important changes, please head over to GitHub. If you already have restic (0.9.4 or later), you can use the self-update command to automatically download and verify the new release.
-This new release contains a highly anticipated feature on Windows: being able to automatically create a Volume Shadow Copy (VSS) using restic backup --use-fs-snapshot.</description>
+      <description>Restic 0.11.0 was released today! For downloading the new release and to see a more detailed list of important changes, please head over to GitHub. If you already have restic (0.9.4 or later), you can use the self-update command to automatically download and verify the new release.&#xA;This new release contains a highly anticipated feature on Windows: being able to automatically create a Volume Shadow Copy (VSS) using restic backup --use-fs-snapshot.</description>
     </item>
     <item>
       <title>restic 0.10.0 released</title>
       <link>https://restic.net/blog/2020-09-19/restic-0.10.0-released/</link>
       <pubDate>Sat, 19 Sep 2020 17:44:59 +0200</pubDate>
       <guid>https://restic.net/blog/2020-09-19/restic-0.10.0-released/</guid>
-      <description>After ten months of work we&amp;rsquo;ve just released restic 0.10.0! For downloading the new release and to see a more detailed list of important changes, please head over to GitHub. If you already have restic (0.9.4 or later), you can use the self-update command to automatically download and verify the new release.
-This release contains a lot of improvements, both smaller and bigger ones, and the restic project wishes to send a big thank you to everyone who contributed to make this happen.</description>
+      <description>After ten months of work we&amp;rsquo;ve just released restic 0.10.0! For downloading the new release and to see a more detailed list of important changes, please head over to GitHub. If you already have restic (0.9.4 or later), you can use the self-update command to automatically download and verify the new release.&#xA;This release contains a lot of improvements, both smaller and bigger ones, and the restic project wishes to send a big thank you to everyone who contributed to make this happen.</description>
     </item>
     <item>
       <title>Rest Server 0.10.0 Released</title>
       <link>https://restic.net/blog/2020-09-13/rest-server-0.10.0-released/</link>
       <pubDate>Sun, 13 Sep 2020 11:47:00 +0200</pubDate>
       <guid>https://restic.net/blog/2020-09-13/rest-server-0.10.0-released/</guid>
-      <description>We have just released rest-server 0.10.0 which includes a few potentially breaking changes. For details, please see the changes described in the release.
-This release corrects a security issue. User wojas discovered that it was possible to access repositories belonging to other users. It was not possible to access directories outside of the path the repositories were stored in.
-The rest-server has an option to allow users (identify by HTTP Basic authentication) to only access their own repository by specifying the --private-repos option.</description>
+      <description>We have just released rest-server 0.10.0 which includes a few potentially breaking changes. For details, please see the changes described in the release.&#xA;This release corrects a security issue. User wojas discovered that it was possible to access repositories belonging to other users. It was not possible to access directories outside of the path the repositories were stored in.&#xA;The rest-server has an option to allow users (identify by HTTP Basic authentication) to only access their own repository by specifying the --private-repos option.</description>
     </item>
     <item>
       <title>restic 0.9.6 released</title>
       <link>https://restic.net/blog/2019-11-22/restic-0.9.6-released/</link>
       <pubDate>Fri, 22 Nov 2019 00:00:00 +0000</pubDate>
       <guid>https://restic.net/blog/2019-11-22/restic-0.9.6-released/</guid>
-      <description>We&amp;rsquo;ve just released restic 0.9.6. For downloading the new release and see a more detailed list of important changes, head over to GitHub. If you already have restic (0.9.4 or later), you can use the self-update command to automatically download and verify the new release.
-As always, thanks for reporting any issues you encounter! Or just write a post in the forum.</description>
+      <description>We&amp;rsquo;ve just released restic 0.9.6. For downloading the new release and see a more detailed list of important changes, head over to GitHub. If you already have restic (0.9.4 or later), you can use the self-update command to automatically download and verify the new release.&#xA;As always, thanks for reporting any issues you encounter! Or just write a post in the forum.</description>
     </item>
     <item>
       <title>restic 0.9.5 released</title>
       <link>https://restic.net/blog/2019-04-23/restic-0.9.5-released/</link>
       <pubDate>Tue, 23 Apr 2019 00:00:00 +0000</pubDate>
       <guid>https://restic.net/blog/2019-04-23/restic-0.9.5-released/</guid>
-      <description>We&amp;rsquo;ve just released restic 0.9.5. For downloading the new release and see a more detailed list of important changes, head over to GitHub. If you already have restic 0.9.4, you can use the self-update command to automatically download and verify the new release.
-As always, thanks for reporting any issues you encounter! Or just write a post in the forum.</description>
+      <description>We&amp;rsquo;ve just released restic 0.9.5. For downloading the new release and see a more detailed list of important changes, head over to GitHub. If you already have restic 0.9.4, you can use the self-update command to automatically download and verify the new release.&#xA;As always, thanks for reporting any issues you encounter! Or just write a post in the forum.</description>
     </item>
     <item>
       <title>restic 0.9.4 released</title>
       <link>https://restic.net/blog/2019-01-06/restic-0.9.4-released/</link>
       <pubDate>Sun, 06 Jan 2019 00:00:00 +0000</pubDate>
       <guid>https://restic.net/blog/2019-01-06/restic-0.9.4-released/</guid>
-      <description>We&amp;rsquo;ve just released restic 0.9.4. Besides several fixes for bugs it contains a new restorer implementation which downloads data concurrently, so it is much faster than the old one.
-For downloading the new release and see a more detailed list of important changes, head over to GitHub. If you already have restic 0.9.3, you can use the self-update command to automatically download and verify the new release. Due to a bug you need to specify where restic should write the new file, e.</description>
+      <description>We&amp;rsquo;ve just released restic 0.9.4. Besides several fixes for bugs it contains a new restorer implementation which downloads data concurrently, so it is much faster than the old one.&#xA;For downloading the new release and see a more detailed list of important changes, head over to GitHub. If you already have restic 0.9.3, you can use the self-update command to automatically download and verify the new release. Due to a bug you need to specify where restic should write the new file, e.</description>
     </item>
     <item>
       <title>New Year, New Infrastructure!</title>
       <link>https://restic.net/blog/2019-01-01/new-infrastructure/</link>
       <pubDate>Tue, 01 Jan 2019 00:00:00 +0000</pubDate>
       <guid>https://restic.net/blog/2019-01-01/new-infrastructure/</guid>
-      <description>We wish you a happy new year 2019!
-Our friends at hosting.de recently provided us with a dedicated server to host this website, the forum, and the beta builder for restic, and we&amp;rsquo;ve just moved everything over. Thank you very much for your support!
-Please leave a comment in the forum in the thread for this announcement if there&amp;rsquo;s anything broken for you.</description>
+      <description>We wish you a happy new year 2019!&#xA;Our friends at hosting.de recently provided us with a dedicated server to host this website, the forum, and the beta builder for restic, and we&amp;rsquo;ve just moved everything over. Thank you very much for your support!&#xA;Please leave a comment in the forum in the thread for this announcement if there&amp;rsquo;s anything broken for you.</description>
     </item>
     <item>
       <title>restic 0.9.3 released</title>
       <link>https://restic.net/blog/2018-10-13/restic-0.9.3-released/</link>
       <pubDate>Sat, 13 Oct 2018 00:00:00 +0000</pubDate>
       <guid>https://restic.net/blog/2018-10-13/restic-0.9.3-released/</guid>
-      <description>We&amp;rsquo;ve just released restic 0.9.3. It is mostly a maintenance release, but several smaller enhancements have been added.
-For downloading the new release and see a more detailed list of important changes, head over to GitHub. As always, thanks for reporting any issues you encounter! Or just write a post in the forum.</description>
+      <description>We&amp;rsquo;ve just released restic 0.9.3. It is mostly a maintenance release, but several smaller enhancements have been added.&#xA;For downloading the new release and see a more detailed list of important changes, head over to GitHub. As always, thanks for reporting any issues you encounter! Or just write a post in the forum.</description>
     </item>
     <item>
       <title>Configuring GitHub Issue Templates</title>
@@ -206,150 +174,126 @@ For downloading the new release and see a more detailed list of important change
       <link>https://restic.net/blog/2018-09-02/travis-build-cache/</link>
       <pubDate>Sun, 02 Sep 2018 00:00:00 +0000</pubDate>
       <guid>https://restic.net/blog/2018-09-02/travis-build-cache/</guid>
-      <description>The restic project runs the unit and integration tests for each pushed commit and each pull request. We&amp;rsquo;re using Travis CI for Linux and OS X, and AppVeyor for Windows. We&amp;rsquo;re very grateful that they provide their services free of charge for Open Source projects!
-Our project not only runs the tests on Travis, but also compiles restic for each supported architecture, operating system, and version of Go. Go is known for its fast compilation times, but still, compilation takes its time.</description>
+      <description>The restic project runs the unit and integration tests for each pushed commit and each pull request. We&amp;rsquo;re using Travis CI for Linux and OS X, and AppVeyor for Windows. We&amp;rsquo;re very grateful that they provide their services free of charge for Open Source projects!&#xA;Our project not only runs the tests on Travis, but also compiles restic for each supported architecture, operating system, and version of Go. Go is known for its fast compilation times, but still, compilation takes its time.</description>
     </item>
     <item>
       <title>restic 0.9.2 released</title>
       <link>https://restic.net/blog/2018-08-06/restic-0.9.2-released/</link>
       <pubDate>Mon, 06 Aug 2018 00:00:00 +0000</pubDate>
       <guid>https://restic.net/blog/2018-08-06/restic-0.9.2-released/</guid>
-      <description>We&amp;rsquo;ve just released restic 0.9.2. Among several fixes it includes support for &amp;ldquo;Application Keys&amp;rdquo; for BackBlaze B2, which can be restricted to a specific bucket and/or path (so you don&amp;rsquo;t have to give restic access to all your files stored at B2).
-For downloading the new release and see a more detailed list of important changes, head over to GitHub. As always, thanks for reporting any issues you encounter! Or just write a post in the forum.</description>
+      <description>We&amp;rsquo;ve just released restic 0.9.2. Among several fixes it includes support for &amp;ldquo;Application Keys&amp;rdquo; for BackBlaze B2, which can be restricted to a specific bucket and/or path (so you don&amp;rsquo;t have to give restic access to all your files stored at B2).&#xA;For downloading the new release and see a more detailed list of important changes, head over to GitHub. As always, thanks for reporting any issues you encounter! Or just write a post in the forum.</description>
     </item>
     <item>
       <title>restic 0.9.1 released</title>
       <link>https://restic.net/blog/2018-06-10/restic-0.9.1-released/</link>
       <pubDate>Sun, 10 Jun 2018 00:00:00 +0000</pubDate>
       <guid>https://restic.net/blog/2018-06-10/restic-0.9.1-released/</guid>
-      <description>We&amp;rsquo;ve just released restic 0.9.1, a minor bugfix release.
-For downloading the new release and see a more detailed list of important changes, head over to GitHub. As always, thanks for reporting any issues you encounter! Or just write a post in the forum.</description>
+      <description>We&amp;rsquo;ve just released restic 0.9.1, a minor bugfix release.&#xA;For downloading the new release and see a more detailed list of important changes, head over to GitHub. As always, thanks for reporting any issues you encounter! Or just write a post in the forum.</description>
     </item>
     <item>
       <title>restic 0.9.0 released</title>
       <link>https://restic.net/blog/2018-05-21/restic-0.9.0-released/</link>
       <pubDate>Mon, 21 May 2018 00:00:00 +0000</pubDate>
       <guid>https://restic.net/blog/2018-05-21/restic-0.9.0-released/</guid>
-      <description>We&amp;rsquo;ve just released restic 0.9.0. This is the next bigger release since 0.8.0, it mainly brings a completely rewritten archiver core, improves the speed for restic check, and many bug fixes.
-For downloading the new release and see a more detailed list of important changes, head over to GitHub. As always, thanks for reporting any issues you encounter! Or just write a post in the forum.</description>
+      <description>We&amp;rsquo;ve just released restic 0.9.0. This is the next bigger release since 0.8.0, it mainly brings a completely rewritten archiver core, improves the speed for restic check, and many bug fixes.&#xA;For downloading the new release and see a more detailed list of important changes, head over to GitHub. As always, thanks for reporting any issues you encounter! Or just write a post in the forum.</description>
     </item>
     <item>
       <title>The restic project turns four!</title>
       <link>https://restic.net/blog/2018-04-06/restic-turns-four/</link>
       <pubDate>Fri, 06 Apr 2018 00:00:00 +0000</pubDate>
       <guid>https://restic.net/blog/2018-04-06/restic-turns-four/</guid>
-      <description>Four years ago on 2014-04-06 fd0 added the first commit to what would later become the restic repository. At the time it was code-named khepri, but unfortunately the name wasn&amp;rsquo;t available on GitHub any more, so we had to find a different one.
-At the moment, restic&amp;rsquo;s repository was starred on GitHub almost four thousand times. And we&amp;rsquo;ve collected 56 other backup tools along the way, helping countless people to discover backup programs (not necessarily restic alone).</description>
+      <description>Four years ago on 2014-04-06 fd0 added the first commit to what would later become the restic repository. At the time it was code-named khepri, but unfortunately the name wasn&amp;rsquo;t available on GitHub any more, so we had to find a different one.&#xA;At the moment, restic&amp;rsquo;s repository was starred on GitHub almost four thousand times. And we&amp;rsquo;ve collected 56 other backup tools along the way, helping countless people to discover backup programs (not necessarily restic alone).</description>
     </item>
     <item>
       <title>Using rclone as a restic Backend</title>
       <link>https://restic.net/blog/2018-04-01/rclone-backend/</link>
       <pubDate>Sun, 01 Apr 2018 00:00:00 +0000</pubDate>
       <guid>https://restic.net/blog/2018-04-01/rclone-backend/</guid>
-      <description>Originally, restic started with just two backends: local and sftp. Over time, many new backends were added so that restic is now able to store a repository on a variety of different cloud-based services. However, it became clear that each new backend we add for a new cloud service works slightly different and requires almost constant maintenance.
-A while ago, Alex was contacted by Nick, who found restic by listening to the episode #48 of the GoTime podcast.</description>
+      <description>Originally, restic started with just two backends: local and sftp. Over time, many new backends were added so that restic is now able to store a repository on a variety of different cloud-based services. However, it became clear that each new backend we add for a new cloud service works slightly different and requires almost constant maintenance.&#xA;A while ago, Alex was contacted by Nick, who found restic by listening to the episode #48 of the GoTime podcast.</description>
     </item>
     <item>
       <title>restic 0.8.3 released</title>
       <link>https://restic.net/blog/2018-02-26/restic-0.8.3-released/</link>
       <pubDate>Mon, 26 Feb 2018 00:00:00 +0000</pubDate>
       <guid>https://restic.net/blog/2018-02-26/restic-0.8.3-released/</guid>
-      <description>We&amp;rsquo;ve just released restic 0.8.3. This is again a bugfix release, but also several improvements for cloud-based backends.
-For downloading the new release and see a more detailed list of important changes, head over to GitHub. As always, thanks for reporting any issues you encounter! Or just write a post in the forum.</description>
+      <description>We&amp;rsquo;ve just released restic 0.8.3. This is again a bugfix release, but also several improvements for cloud-based backends.&#xA;For downloading the new release and see a more detailed list of important changes, head over to GitHub. As always, thanks for reporting any issues you encounter! Or just write a post in the forum.</description>
     </item>
     <item>
       <title>restic 0.8.2 released</title>
       <link>https://restic.net/blog/2018-02-17/restic-0.8.2-released/</link>
       <pubDate>Sat, 17 Feb 2018 00:00:00 +0000</pubDate>
       <guid>https://restic.net/blog/2018-02-17/restic-0.8.2-released/</guid>
-      <description>We&amp;rsquo;ve just released restic 0.8.2. This is mostly a bugfix release, with some smaller enhancements.
-For downloading the new release and see a more detailed list of important changes, head over to GitHub. As always, thanks for reporting any issues you encounter! Or just write a post in the forum.</description>
+      <description>We&amp;rsquo;ve just released restic 0.8.2. This is mostly a bugfix release, with some smaller enhancements.&#xA;For downloading the new release and see a more detailed list of important changes, head over to GitHub. As always, thanks for reporting any issues you encounter! Or just write a post in the forum.</description>
     </item>
     <item>
       <title>moving to restic.net</title>
       <link>https://restic.net/blog/2018-01-01/moving-domain/</link>
       <pubDate>Mon, 01 Jan 2018 00:00:00 +0000</pubDate>
       <guid>https://restic.net/blog/2018-01-01/moving-domain/</guid>
-      <description>A while back we&amp;rsquo;ve registered the domain restic.net and we&amp;rsquo;re moving the website from GitHub Pages to a dedicated hosting machine at https://restic.net. Please update any links to the old website, thanks!
-If you&amp;rsquo;re subscribed to the RSS/Atom XML feed, you need to update the feed url to https://restic.net/feed.xml.
-Update: When we migrated the website to Hugo in 2020, the feed changed from Atom at the above mentioned URL to RSS 2.</description>
+      <description>A while back we&amp;rsquo;ve registered the domain restic.net and we&amp;rsquo;re moving the website from GitHub Pages to a dedicated hosting machine at https://restic.net. Please update any links to the old website, thanks!&#xA;If you&amp;rsquo;re subscribed to the RSS/Atom XML feed, you need to update the feed url to https://restic.net/feed.xml.&#xA;Update: When we migrated the website to Hugo in 2020, the feed changed from Atom at the above mentioned URL to RSS 2.</description>
     </item>
     <item>
       <title>restic 0.8.1 released</title>
       <link>https://restic.net/blog/2017-12-27/restic-0.8.1-released/</link>
       <pubDate>Wed, 27 Dec 2017 00:00:00 +0000</pubDate>
       <guid>https://restic.net/blog/2017-12-27/restic-0.8.1-released/</guid>
-      <description>We&amp;rsquo;ve just released restic 0.8.1. Among others, support for DigitalOcean Spaces (and other backends which use HTTP) is improved.
-For downloading the new release and see a more detailed list of important changes, head over to GitHub. As always, thanks for reporting any issues you encounter! Or just write a post in the forum.</description>
+      <description>We&amp;rsquo;ve just released restic 0.8.1. Among others, support for DigitalOcean Spaces (and other backends which use HTTP) is improved.&#xA;For downloading the new release and see a more detailed list of important changes, head over to GitHub. As always, thanks for reporting any issues you encounter! Or just write a post in the forum.</description>
     </item>
     <item>
       <title>restic 0.8.0 released</title>
       <link>https://restic.net/blog/2017-11-26/restic-0.8.0-released/</link>
       <pubDate>Sun, 26 Nov 2017 00:00:00 +0000</pubDate>
       <guid>https://restic.net/blog/2017-11-26/restic-0.8.0-released/</guid>
-      <description>We&amp;rsquo;ve just released restic 0.8.0. It brings the new awesome metadata cache which will speed up many operations, you may need to run restic prune once to fully see it in action.
-For downloading the new release and see a more detailed list of important changes, head over to GitHub. As always, thanks for reporting any issues you encounter! Or just write a post in the forum.
-This release also corrects a (low risk) vulnerability.</description>
+      <description>We&amp;rsquo;ve just released restic 0.8.0. It brings the new awesome metadata cache which will speed up many operations, you may need to run restic prune once to fully see it in action.&#xA;For downloading the new release and see a more detailed list of important changes, head over to GitHub. As always, thanks for reporting any issues you encounter! Or just write a post in the forum.&#xA;This release also corrects a (low risk) vulnerability.</description>
     </item>
     <item>
       <title>Upcoming changes for the S3 backend</title>
       <link>https://restic.net/blog/2017-11-25/upcoming-changes-to-s3/</link>
       <pubDate>Sat, 25 Nov 2017 00:00:00 +0000</pubDate>
       <guid>https://restic.net/blog/2017-11-25/upcoming-changes-to-s3/</guid>
-      <description>TL;DR: If you&amp;rsquo;re using the s3 backend and cannot access your repo any more, append the path /restic to the repository location.
-We&amp;rsquo;ve just merged Pull Request #1437 which resolves an issue with the S3 backend reported in #1292. When the next restic version is released (or you&amp;rsquo;re using the master branch directly), this may require modifying the repository location you&amp;rsquo;re passing to restic.
-In order to access a repository stored on S3, restic requires the following information:</description>
+      <description>TL;DR: If you&amp;rsquo;re using the s3 backend and cannot access your repo any more, append the path /restic to the repository location.&#xA;We&amp;rsquo;ve just merged Pull Request #1437 which resolves an issue with the S3 backend reported in #1292. When the next restic version is released (or you&amp;rsquo;re using the master branch directly), this may require modifying the repository location you&amp;rsquo;re passing to restic.&#xA;In order to access a repository stored on S3, restic requires the following information:</description>
     </item>
     <item>
       <title>restic 0.7.3 released</title>
       <link>https://restic.net/blog/2017-09-20/restic-0.7.3-released/</link>
       <pubDate>Wed, 20 Sep 2017 00:00:00 +0000</pubDate>
       <guid>https://restic.net/blog/2017-09-20/restic-0.7.3-released/</guid>
-      <description>We&amp;rsquo;ve just released restic 0.7.3 to correct a bug with the Google Cloud Storage and Azure backends. When restic prune or restic rebuild-index was run, not all files stored in these backends were considered.
-For downloading the code, head over to GitHub. As always, thanks for reporting any issues you encounter!
-The binaries released with each restic version are reproducible, which means that you can easily reproduce a byte identical version from the source code for that release.</description>
+      <description>We&amp;rsquo;ve just released restic 0.7.3 to correct a bug with the Google Cloud Storage and Azure backends. When restic prune or restic rebuild-index was run, not all files stored in these backends were considered.&#xA;For downloading the code, head over to GitHub. As always, thanks for reporting any issues you encounter!&#xA;The binaries released with each restic version are reproducible, which means that you can easily reproduce a byte identical version from the source code for that release.</description>
     </item>
     <item>
       <title>restic 0.7.2 released</title>
       <link>https://restic.net/blog/2017-09-13/restic-0.7.2-released/</link>
       <pubDate>Wed, 13 Sep 2017 00:00:00 +0000</pubDate>
       <guid>https://restic.net/blog/2017-09-13/restic-0.7.2-released/</guid>
-      <description>We&amp;rsquo;re very pleased to announce that restic 0.7.2 has been released! For downloading the code, head over to GitHub. As always, thanks for reporting any issues you encounter!
-The binaries released with each restic version are reproducible, which means that you can easily reproduce a byte identical version from the source code for that release. Instructions on how to do that are contained in the builder repository.
-Important Changes in 0.</description>
+      <description>We&amp;rsquo;re very pleased to announce that restic 0.7.2 has been released! For downloading the code, head over to GitHub. As always, thanks for reporting any issues you encounter!&#xA;The binaries released with each restic version are reproducible, which means that you can easily reproduce a byte identical version from the source code for that release. Instructions on how to do that are contained in the builder repository.&#xA;Important Changes in 0.</description>
     </item>
     <item>
       <title>Meeting at FrOSCon 2017 - Details</title>
       <link>https://restic.net/blog/2017-08-14/FrOSCon-Bonn-Details/</link>
       <pubDate>Mon, 14 Aug 2017 00:00:00 +0000</pubDate>
       <guid>https://restic.net/blog/2017-08-14/FrOSCon-Bonn-Details/</guid>
-      <description>As announced a few weeks ago we&amp;rsquo;re meeting at this year&amp;rsquo;s FrOSCon on 19 August 2017, 15:00 CEST in Sankt Augustin near Bonn/Cologne in Germany (free entry)! We&amp;rsquo;ll get a project room for the afternoon, the room number will be announced as an update to this blog entry, on Twitter and in the forum.
-It&amp;rsquo;d be nice to know how many of you will be able to join us, so please leave a comment in the GitHub issue #1110 or in the forum.</description>
+      <description>As announced a few weeks ago we&amp;rsquo;re meeting at this year&amp;rsquo;s FrOSCon on 19 August 2017, 15:00 CEST in Sankt Augustin near Bonn/Cologne in Germany (free entry)! We&amp;rsquo;ll get a project room for the afternoon, the room number will be announced as an update to this blog entry, on Twitter and in the forum.&#xA;It&amp;rsquo;d be nice to know how many of you will be able to join us, so please leave a comment in the GitHub issue #1110 or in the forum.</description>
     </item>
     <item>
       <title>Discourse Forum</title>
       <link>https://restic.net/blog/2017-08-11/discourse-forum/</link>
       <pubDate>Fri, 11 Aug 2017 00:00:00 +0000</pubDate>
       <guid>https://restic.net/blog/2017-08-11/discourse-forum/</guid>
-      <description>We&amp;rsquo;ve noticed that there are many questions raised as issues on GitHub, so we&amp;rsquo;ve installed a Discourse forum at https://forum.restic.net! For now, this is an experiment to see if a forum is better suited to answer questions. We&amp;rsquo;ll see how that goes.
-Please let us know any feedback you have (in the forum, obviously)!</description>
+      <description>We&amp;rsquo;ve noticed that there are many questions raised as issues on GitHub, so we&amp;rsquo;ve installed a Discourse forum at https://forum.restic.net! For now, this is an experiment to see if a forum is better suited to answer questions. We&amp;rsquo;ll see how that goes.&#xA;Please let us know any feedback you have (in the forum, obviously)!</description>
     </item>
     <item>
       <title>Please upgrade to restic 0.7.1!</title>
       <link>https://restic.net/blog/2017-07-25/please-upgrade-to-0.7.1/</link>
       <pubDate>Tue, 25 Jul 2017 00:00:00 +0000</pubDate>
       <guid>https://restic.net/blog/2017-07-25/please-upgrade-to-0.7.1/</guid>
-      <description>TL;DR:
-Under some circumstances, data in the repo was not stored properly This could have caused incomplete backups Upgrade restic to at least 0.7.1 and run restic rebuild-index before the next backup It is good practice to run restic check regularly Background We always knew that at some point there may be a more serious bug in restic that warrants a broader announcement. This is the story of how a small improvement that makes the code even more conservative lead to a small error which then caused a couple of unintended consequences.</description>
+      <description>TL;DR:&#xA;Under some circumstances, data in the repo was not stored properly This could have caused incomplete backups Upgrade restic to at least 0.7.1 and run restic rebuild-index before the next backup It is good practice to run restic check regularly Background We always knew that at some point there may be a more serious bug in restic that warrants a broader announcement. This is the story of how a small improvement that makes the code even more conservative lead to a small error which then caused a couple of unintended consequences.</description>
     </item>
     <item>
       <title>restic 0.7.1 released</title>
       <link>https://restic.net/blog/2017-07-22/restic-0.7.1-released/</link>
       <pubDate>Sat, 22 Jul 2017 00:00:00 +0000</pubDate>
       <guid>https://restic.net/blog/2017-07-22/restic-0.7.1-released/</guid>
-      <description>We&amp;rsquo;re proud to present restic 0.7.1! For downloading the code, head over to GitHub. As always, thanks for reporting any issues you encounter!
-The binaries released with each restic version starting are reproducible, which means that you can easily reproduce a byte identical version from the source code for that release. Instructions on how to do that are contained in the builder repository.
-Important Changes in 0.7.1 The migrate command for changing the s3legacy layout to the default layout for s3 backends has been improved: It can now be restarted with restic migrate --force s3_layout and automatically retries operations on error.</description>
+      <description>We&amp;rsquo;re proud to present restic 0.7.1! For downloading the code, head over to GitHub. As always, thanks for reporting any issues you encounter!&#xA;The binaries released with each restic version starting are reproducible, which means that you can easily reproduce a byte identical version from the source code for that release. Instructions on how to do that are contained in the builder repository.&#xA;Important Changes in 0.7.1 The migrate command for changing the s3legacy layout to the default layout for s3 backends has been improved: It can now be restarted with restic migrate --force s3_layout and automatically retries operations on error.</description>
     </item>
     <item>
       <title>Meeting at FrOSCon 2017</title>
@@ -363,64 +307,49 @@ Important Changes in 0.7.1 The migrate command for changing the s3legacy layout 
       <link>https://restic.net/blog/2017-07-01/restic-0.7.0-released/</link>
       <pubDate>Sat, 01 Jul 2017 00:00:00 +0000</pubDate>
       <guid>https://restic.net/blog/2017-07-01/restic-0.7.0-released/</guid>
-      <description>We&amp;rsquo;ve just released restic 0.7.0! For downloading the code, head over to GitHub. As always, thanks for reporting any issues you encounter!
-Important Changes in 0.7.0 New &amp;ldquo;swift&amp;rdquo; backend: A new backend for the OpenStack Swift cloud storage protocol has been added, https://wiki.openstack.org/wiki/Swift https://github.com/restic/restic/pull/975 https://github.com/restic/restic/pull/648
-New &amp;ldquo;b2&amp;rdquo; backend: A new backend for Backblaze B2 cloud storage service has been added, https://www.backblaze.com https://github.com/restic/restic/issues/512 https://github.com/restic/restic/pull/978
-Improved performance for the find command: Restic recognizes paths it has already checked for the files in question, so the number of backend requests is reduced a lot.</description>
+      <description>We&amp;rsquo;ve just released restic 0.7.0! For downloading the code, head over to GitHub. As always, thanks for reporting any issues you encounter!&#xA;Important Changes in 0.7.0 New &amp;ldquo;swift&amp;rdquo; backend: A new backend for the OpenStack Swift cloud storage protocol has been added, https://wiki.openstack.org/wiki/Swift https://github.com/restic/restic/pull/975 https://github.com/restic/restic/pull/648&#xA;New &amp;ldquo;b2&amp;rdquo; backend: A new backend for Backblaze B2 cloud storage service has been added, https://www.backblaze.com https://github.com/restic/restic/issues/512 https://github.com/restic/restic/pull/978&#xA;Improved performance for the find command: Restic recognizes paths it has already checked for the files in question, so the number of backend requests is reduced a lot.</description>
     </item>
     <item>
       <title>restic on GoTime #48</title>
       <link>https://restic.net/blog/2017-06-01/restic-on-gotime/</link>
       <pubDate>Thu, 01 Jun 2017 00:00:00 +0000</pubDate>
       <guid>https://restic.net/blog/2017-06-01/restic-on-gotime/</guid>
-      <description>Last week Alex had the honour to join Ashley, Erik, and Brian at GoTime. GoTime is a podcast about Go, the community, and everything in between. It was a lot of fun (and he got to do the intro in German). The episode can be found on the website, you can also listen to it right here:
-Go Time 48: Restic and Backups (Done Right) with Alexander Neumann – Listen on Changelog.</description>
+      <description>Last week Alex had the honour to join Ashley, Erik, and Brian at GoTime. GoTime is a podcast about Go, the community, and everything in between. It was a lot of fun (and he got to do the intro in German). The episode can be found on the website, you can also listen to it right here:&#xA;Go Time 48: Restic and Backups (Done Right) with Alexander Neumann – Listen on Changelog.</description>
     </item>
     <item>
       <title>restic 0.6.0 released</title>
       <link>https://restic.net/blog/2017-05-29/restic-0.6.0-released/</link>
       <pubDate>Mon, 29 May 2017 00:00:00 +0000</pubDate>
       <guid>https://restic.net/blog/2017-05-29/restic-0.6.0-released/</guid>
-      <description>We&amp;rsquo;ve just released restic 0.6.0!
-No grave bugs have been found, so the final version is identical to the -rc.1 version. This release contains many bug fixes and several improvements for the user interface, the most important changes are listed below (and also contained in the CHANGELOG.md.
-For downloading the code, head over to https://github.com/restic/restic/releases/tag/v0.6.0. As always, thanks for reporting any issues you encounter!
-Important Changes in 0.6.0 Consistent forget policy The forget command was corrected to be more consistent in which snapshots are to be forgotten.</description>
+      <description>We&amp;rsquo;ve just released restic 0.6.0!&#xA;No grave bugs have been found, so the final version is identical to the -rc.1 version. This release contains many bug fixes and several improvements for the user interface, the most important changes are listed below (and also contained in the CHANGELOG.md.&#xA;For downloading the code, head over to https://github.com/restic/restic/releases/tag/v0.6.0. As always, thanks for reporting any issues you encounter!&#xA;Important Changes in 0.6.0 Consistent forget policy The forget command was corrected to be more consistent in which snapshots are to be forgotten.</description>
     </item>
     <item>
       <title>restic 0.6.1 released</title>
       <link>https://restic.net/blog/2017-05-29/restic-0.6.1-released/</link>
       <pubDate>Mon, 29 May 2017 00:00:00 +0000</pubDate>
       <guid>https://restic.net/blog/2017-05-29/restic-0.6.1-released/</guid>
-      <description>We&amp;rsquo;ve just released restic 0.6.1!
-Just a few days after the release of restic 0.6.0 we&amp;rsquo;ve released 0.6.1 as a bugfix release to address two annoying bugs. The changes are listed below.
-This is the first release of restic that uses the new build Docker container which allows you to reproduce a byte identical version of the released binaries. This is called Reproducible Builds.
-For downloading the code, head over to GitHub.</description>
+      <description>We&amp;rsquo;ve just released restic 0.6.1!&#xA;Just a few days after the release of restic 0.6.0 we&amp;rsquo;ve released 0.6.1 as a bugfix release to address two annoying bugs. The changes are listed below.&#xA;This is the first release of restic that uses the new build Docker container which allows you to reproduce a byte identical version of the released binaries. This is called Reproducible Builds.&#xA;For downloading the code, head over to GitHub.</description>
     </item>
     <item>
       <title>restic 0.6.0-rc.1 released</title>
       <link>https://restic.net/blog/2017-05-25/restic-0.6.0-rc.1-released/</link>
       <pubDate>Thu, 25 May 2017 00:00:00 +0000</pubDate>
       <guid>https://restic.net/blog/2017-05-25/restic-0.6.0-rc.1-released/</guid>
-      <description>We&amp;rsquo;ve just released restic 0.6.0-rc.1!
-This is the Release Candidate version. If no grave bugs occur, it will be released as the final version in a few days. This release contains many bug fixes and several improvements for the user interface, the most important changes are listed below (and also contained in the CHANGELOG.md.
-For downloading the code, head over to https://github.com/restic/restic/releases/tag/v0.6.0-rc.1 As always, thanks for reporting any issues you encounter!</description>
+      <description>We&amp;rsquo;ve just released restic 0.6.0-rc.1!&#xA;This is the Release Candidate version. If no grave bugs occur, it will be released as the final version in a few days. This release contains many bug fixes and several improvements for the user interface, the most important changes are listed below (and also contained in the CHANGELOG.md.&#xA;For downloading the code, head over to https://github.com/restic/restic/releases/tag/v0.6.0-rc.1 As always, thanks for reporting any issues you encounter!</description>
     </item>
     <item>
       <title>restic 0.5.0 released</title>
       <link>https://restic.net/blog/2017-03-11/restic-0.5.0-released/</link>
       <pubDate>Sat, 11 Mar 2017 00:00:00 +0000</pubDate>
       <guid>https://restic.net/blog/2017-03-11/restic-0.5.0-released/</guid>
-      <description>We&amp;rsquo;ve just released restic 0.5.0.
-This release contains (among many bug fixes) several improvements to the user interface:
-more progress bars consistent filtering for tags, hostname, or path a new command tag which allows modifying tags of existing snapshots Since we&amp;rsquo;ve internally started using the new context package, Go 1.7 is now required for compiling restic. Running build.go will check this for you. The released binaries have been compiled with Go 1.</description>
+      <description>We&amp;rsquo;ve just released restic 0.5.0.&#xA;This release contains (among many bug fixes) several improvements to the user interface:&#xA;more progress bars consistent filtering for tags, hostname, or path a new command tag which allows modifying tags of existing snapshots Since we&amp;rsquo;ve internally started using the new context package, Go 1.7 is now required for compiling restic. Running build.go will check this for you. The released binaries have been compiled with Go 1.</description>
     </item>
     <item>
       <title>restic 0.4.0 released</title>
       <link>https://restic.net/blog/2017-02-02/restic-0.4.0-released/</link>
       <pubDate>Thu, 02 Feb 2017 00:00:00 +0000</pubDate>
       <guid>https://restic.net/blog/2017-02-02/restic-0.4.0-released/</guid>
-      <description>We&amp;rsquo;ve just released restic 0.4.0. This release will use much less memory during certain operations (notably prune, but also during backup). There have also been some major internal changes which will hopefully contribute to an even larger improvement in memory usage.
-As always, thanks for reporting any issues you encounter!</description>
+      <description>We&amp;rsquo;ve just released restic 0.4.0. This release will use much less memory during certain operations (notably prune, but also during backup). There have also been some major internal changes which will hopefully contribute to an even larger improvement in memory usage.&#xA;As always, thanks for reporting any issues you encounter!</description>
     </item>
     <item>
       <title>The Go Devroom at FOSDEM 2017</title>
@@ -434,102 +363,84 @@ As always, thanks for reporting any issues you encounter!</description>
       <link>https://restic.net/blog/2017-01-08/restic-0.3.3-released/</link>
       <pubDate>Sun, 08 Jan 2017 00:00:00 +0000</pubDate>
       <guid>https://restic.net/blog/2017-01-08/restic-0.3.3-released/</guid>
-      <description>We&amp;rsquo;ve released another minor version: restic 0.3.3. As always, thanks for reporting any issues you encounter!
-Recently, several people worked together to create and upload an official Debian package for restic. A few days ago on 2 January 2017, that package entered the testing distribution, so restic will be part of the next Debian stable release!</description>
+      <description>We&amp;rsquo;ve released another minor version: restic 0.3.3. As always, thanks for reporting any issues you encounter!&#xA;Recently, several people worked together to create and upload an official Debian package for restic. A few days ago on 2 January 2017, that package entered the testing distribution, so restic will be part of the next Debian stable release!</description>
     </item>
     <item>
       <title>restic 0.3.2 released</title>
       <link>https://restic.net/blog/2016-12-18/restic-0.3.2-released/</link>
       <pubDate>Sun, 18 Dec 2016 00:00:00 +0000</pubDate>
       <guid>https://restic.net/blog/2016-12-18/restic-0.3.2-released/</guid>
-      <description>A few days ago we&amp;rsquo;ve released restic 0.3.1, unfortunately that introduced a bug which let&amp;rsquo;s restic panic when there is an error during backup. The details are described in GitHub issues #699 and #700.
-So, here it is: restic version 0.3.2.
-As always, thanks for reporting any issues you encounter!</description>
+      <description>A few days ago we&amp;rsquo;ve released restic 0.3.1, unfortunately that introduced a bug which let&amp;rsquo;s restic panic when there is an error during backup. The details are described in GitHub issues #699 and #700.&#xA;So, here it is: restic version 0.3.2.&#xA;As always, thanks for reporting any issues you encounter!</description>
     </item>
     <item>
       <title>restic 0.3.1 released</title>
       <link>https://restic.net/blog/2016-12-13/restic-0.3.1-released/</link>
       <pubDate>Tue, 13 Dec 2016 00:00:00 +0000</pubDate>
       <guid>https://restic.net/blog/2016-12-13/restic-0.3.1-released/</guid>
-      <description>We&amp;rsquo;re proud to announce the release of restic version 0.3.1. This is mainly a small bugfix release, no major new features have been added.
-The detailed change log can be found in the release notes or on GitHub.
-As always, thanks for reporting any issues you encounter!</description>
+      <description>We&amp;rsquo;re proud to announce the release of restic version 0.3.1. This is mainly a small bugfix release, no major new features have been added.&#xA;The detailed change log can be found in the release notes or on GitHub.&#xA;As always, thanks for reporting any issues you encounter!</description>
     </item>
     <item>
       <title>restic 0.3.0 released</title>
       <link>https://restic.net/blog/2016-10-01/restic-0.3.0-released/</link>
       <pubDate>Sat, 01 Oct 2016 00:00:00 +0000</pubDate>
       <guid>https://restic.net/blog/2016-10-01/restic-0.3.0-released/</guid>
-      <description>After two months development we&amp;rsquo;re proud to release restic version 0.3.0.
-The most notable change is the addition of the prune and forget commands (we&amp;rsquo;ve covered them in an earlier blog post) which allow removing backups from the repository according to configurable criteria. Since this was one of the most requested features, now that it is implemented there&amp;rsquo;s really no excuse for not making backups any more!
-The detailed change log can be found in the release notes or on GitHub.</description>
+      <description>After two months development we&amp;rsquo;re proud to release restic version 0.3.0.&#xA;The most notable change is the addition of the prune and forget commands (we&amp;rsquo;ve covered them in an earlier blog post) which allow removing backups from the repository according to configurable criteria. Since this was one of the most requested features, now that it is implemented there&amp;rsquo;s really no excuse for not making backups any more!&#xA;The detailed change log can be found in the release notes or on GitHub.</description>
     </item>
     <item>
       <title>Removing Snapshots</title>
       <link>https://restic.net/blog/2016-08-22/removing-snapshots/</link>
       <pubDate>Mon, 22 Aug 2016 00:00:00 +0000</pubDate>
       <guid>https://restic.net/blog/2016-08-22/removing-snapshots/</guid>
-      <description>The feature that was most often requested feature for restic is the ability to remove snapshots from the repository. Sometimes, restic was even (rightfully) criticised for not having such a function.
-After about three months of work, PR #518 was merged into the master branch a few days ago. This pull request brings two new commands to restic: forget and prune, which allows you to not only remove a single snapshot manually, but rather specify a policy according to which restic should automatically remove snapshots (so you don&amp;rsquo;t have to bother with them).</description>
+      <description>The feature that was most often requested feature for restic is the ability to remove snapshots from the repository. Sometimes, restic was even (rightfully) criticised for not having such a function.&#xA;After about three months of work, PR #518 was merged into the master branch a few days ago. This pull request brings two new commands to restic: forget and prune, which allows you to not only remove a single snapshot manually, but rather specify a policy according to which restic should automatically remove snapshots (so you don&amp;rsquo;t have to bother with them).</description>
     </item>
     <item>
       <title>restic 0.2.0 released</title>
       <link>https://restic.net/blog/2016-08-05/restic-0.2.0-released/</link>
       <pubDate>Fri, 05 Aug 2016 00:00:00 +0000</pubDate>
       <guid>https://restic.net/blog/2016-08-05/restic-0.2.0-released/</guid>
-      <description>A few days ago we&amp;rsquo;ve released restic 0.2.0, the detailed change log and released files can be found over at GitHub: https://github.com/restic/restic/releases/tag/v0.2.0.
-This release includes around 550 commits since version 0.1.0 (August 2015).</description>
+      <description>A few days ago we&amp;rsquo;ve released restic 0.2.0, the detailed change log and released files can be found over at GitHub: https://github.com/restic/restic/releases/tag/v0.2.0.&#xA;This release includes around 550 commits since version 0.1.0 (August 2015).</description>
     </item>
     <item>
       <title>Documentation and Manual</title>
       <link>https://restic.net/blog/2016-02-24/Documentation/</link>
       <pubDate>Wed, 24 Feb 2016 00:00:00 +0000</pubDate>
       <guid>https://restic.net/blog/2016-02-24/Documentation/</guid>
-      <description>Documentation in software projects is one of the things most developers hate. It is no secret that the docs always seem to be out of date.
-In order to improve this situation for restic, since a few days ago the manual and documentation is part of the main restic repository. Having the documentation in the main repository means that all users have instant access to the exact version of the documentation they&amp;rsquo;ll need and developers can document new features in the same Pull Request they&amp;rsquo;re submitting the code.</description>
+      <description>Documentation in software projects is one of the things most developers hate. It is no secret that the docs always seem to be out of date.&#xA;In order to improve this situation for restic, since a few days ago the manual and documentation is part of the main restic repository. Having the documentation in the main repository means that all users have instant access to the exact version of the documentation they&amp;rsquo;ll need and developers can document new features in the same Pull Request they&amp;rsquo;re submitting the code.</description>
     </item>
     <item>
       <title>OpenChaos at CCC Cologne: restic - Backups mal richtig</title>
       <link>https://restic.net/blog/2016-02-04/CCC-Cologne-OpenChaos/</link>
       <pubDate>Thu, 04 Feb 2016 00:00:00 +0000</pubDate>
       <guid>https://restic.net/blog/2016-02-04/CCC-Cologne-OpenChaos/</guid>
-      <description>On Friday, 30 January fd0 gave a talk at the Chaos Computer Club Cologne (C4) e.V. in Cologne, Germany in their monthly series of public lectures called OpenChaos. Unfortunately for our international readers the talk was given in German.
-The recording is embedded below. If you&amp;rsquo;ve watched the talk and have a question or other feedback, please contact fd0, he&amp;rsquo;d love to hear your feedback!</description>
+      <description>On Friday, 30 January fd0 gave a talk at the Chaos Computer Club Cologne (C4) e.V. in Cologne, Germany in their monthly series of public lectures called OpenChaos. Unfortunately for our international readers the talk was given in German.&#xA;The recording is embedded below. If you&amp;rsquo;ve watched the talk and have a question or other feedback, please contact fd0, he&amp;rsquo;d love to hear your feedback!</description>
     </item>
     <item>
       <title>Verifying Code Archive Integrity</title>
       <link>https://restic.net/blog/2015-09-16/verifying-code-archive-integrity/</link>
       <pubDate>Wed, 16 Sep 2015 00:00:00 +0000</pubDate>
       <guid>https://restic.net/blog/2015-09-16/verifying-code-archive-integrity/</guid>
-      <description>The restic project and all the source code, even this website is hosted by GitHub, and they provide an awesome service! This post describes how we sign releases of restic by using GnuPG so you can independently verify the integrity of the source code. In addition it is show how the automatically generated tar.gz files can be recreated with from the git repository.
-Signing Git Tags In a git repository, &amp;ldquo;tags&amp;rdquo; can be created which basically are just named pointers to a commit, optionally annotated with other data.</description>
+      <description>The restic project and all the source code, even this website is hosted by GitHub, and they provide an awesome service! This post describes how we sign releases of restic by using GnuPG so you can independently verify the integrity of the source code. In addition it is show how the automatically generated tar.gz files can be recreated with from the git repository.&#xA;Signing Git Tags In a git repository, &amp;ldquo;tags&amp;rdquo; can be created which basically are just named pointers to a commit, optionally annotated with other data.</description>
     </item>
     <item>
       <title>Foundation - Introducing Content Defined Chunking (CDC)</title>
       <link>https://restic.net/blog/2015-09-12/restic-foundation1-cdc/</link>
       <pubDate>Sat, 12 Sep 2015 00:00:00 +0000</pubDate>
       <guid>https://restic.net/blog/2015-09-12/restic-foundation1-cdc/</guid>
-      <description>This post will explain Content Defined Chunking (CDC) and how it is used by restic.
-Backup programs need to deal with large volumes of changing data. Saving the whole copy of each file again to the backup location when a subsequent (usually called &amp;ldquo;incremental&amp;rdquo;) backup is created is not efficient. Over time, different strategies have emerged to handle data in such a case.
-In a backup program, data de-duplication can be applied in two locations: Removing duplicate data from the same or different files within the same backup process (inter-file de-duplication), e.</description>
+      <description>This post will explain Content Defined Chunking (CDC) and how it is used by restic.&#xA;Backup programs need to deal with large volumes of changing data. Saving the whole copy of each file again to the backup location when a subsequent (usually called &amp;ldquo;incremental&amp;rdquo;) backup is created is not efficient. Over time, different strategies have emerged to handle data in such a case.&#xA;In a backup program, data de-duplication can be applied in two locations: Removing duplicate data from the same or different files within the same backup process (inter-file de-duplication), e.</description>
     </item>
     <item>
       <title>FrOSCon 2015 Lecture: A Solution to the Backup Inconvenience</title>
       <link>https://restic.net/blog/2015-09-12/FROSCON-2015-talk-about-restic/</link>
       <pubDate>Sat, 12 Sep 2015 00:00:00 +0000</pubDate>
       <guid>https://restic.net/blog/2015-09-12/FROSCON-2015-talk-about-restic/</guid>
-      <description>For the tenth time, FrOSCon took place at the University of Applied Sciences Bonn-Rhein-Sieg in Sankt Augustin near Bonn/Cologne on 22nd and 23rd of August. We took the chance and submitted a talk about restic titled &amp;ldquo;A Solution to the Backup Inconvenience&amp;rdquo;, which was accepted.
-You can watch the recording and view the slides. If you do so, please leave feedback1
-The recording is embedded below:
-[1] The feedback link is non-functional (2020-10-06)</description>
+      <description>For the tenth time, FrOSCon took place at the University of Applied Sciences Bonn-Rhein-Sieg in Sankt Augustin near Bonn/Cologne on 22nd and 23rd of August. We took the chance and submitted a talk about restic titled &amp;ldquo;A Solution to the Backup Inconvenience&amp;rdquo;, which was accepted.&#xA;You can watch the recording and view the slides. If you do so, please leave feedback1&#xA;The recording is embedded below:&#xA;[1] The feedback link is non-functional (2020-10-06)</description>
     </item>
     <item>
       <title>Introduction to the restic Blog - Welcome!</title>
       <link>https://restic.net/blog/2015-09-12/intro/</link>
       <pubDate>Sat, 12 Sep 2015 00:00:00 +0000</pubDate>
       <guid>https://restic.net/blog/2015-09-12/intro/</guid>
-      <description>If you&amp;rsquo;re reading this, you&amp;rsquo;ve found your way to the restic development blog, awesome! Let me welcome you on behalf of the whole development team.
-In this blog we&amp;rsquo;ll publish articles that explain the foundation techniques that restic is built upon and will give some insights into what&amp;rsquo;s happening on the development side of restic. Once restic is widely in use, we&amp;rsquo;ll probably shift the focus a bit towards the user perspective of backups and present tips and tricks for using restic more efficiently.</description>
+      <description>If you&amp;rsquo;re reading this, you&amp;rsquo;ve found your way to the restic development blog, awesome! Let me welcome you on behalf of the whole development team.&#xA;In this blog we&amp;rsquo;ll publish articles that explain the foundation techniques that restic is built upon and will give some insights into what&amp;rsquo;s happening on the development side of restic. Once restic is widely in use, we&amp;rsquo;ll probably shift the focus a bit towards the user perspective of backups and present tips and tricks for using restic more efficiently.</description>
     </item>
   </channel>
 </rss>

--- a/public/categories/index.html
+++ b/public/categories/index.html
@@ -271,8 +271,18 @@
         <a href="/categories/index.xml">RSS Feed</a>
     </div>
 
-    <a href="https://github.com/restic/restic" class="desktop">
-	<img style="position: fixed; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/38ef81f8aca64bb9a64448d0d70f1308ef5341ab/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png">
+    
+<a href="https://github.com/restic/restic" class="github-corner desktop" aria-label="View restic on GitHub">
+	<svg width="80" height="80" viewBox="0 0 250 250" style="fill:#202020; color:#fff; position: absolute; top: 0; border: 0; right: 0;" aria-hidden="true">
+		<title>View restic on GitHub</title>
+		<path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
+		<path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path>
+		<path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path>
+	</svg>
 </a>
+<style>
+	.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}
+</style>
+
   </body>
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -150,7 +150,7 @@
 <li>2016-01-29: <a href="https://media.ccc.de/v/c4.openchaos.2016.01.restic">restic - Backups mal richtig</a>: Public lecture in German at <a href="https://koeln.ccc.de">CCC Cologne e.V.</a> in Cologne, Germany</li>
 <li>2015-08-23: <a href="https://media.ccc.de/browse/conferences/froscon/2015/froscon2015-1515-a_solution_to_the_backup_inconvenience.html">A Solution to the Backup Inconvenience</a>: Lecture at <a href="https://www.froscon.de">FROSCON 2015</a> in Bonn, Germany</li>
 <li>2015-02-01: <a href="https://www.youtube.com/watch?v=oM-MfeflUZ8&amp;t=11m40s">Lightning Talk at FOSDEM 2015</a>: A short introduction (with slightly outdated command line)</li>
-<li>2015-01-27: <a href="https://videoag.fsmpi.rwth-aachen.de/?view=player&amp;lectureid=4442">Talk about restic at CCC Aachen</a> (in German)</li>
+<li>2015-01-27: <a href="https://video.fsmpi.rwth-aachen.de/cccac/4442">Talk about restic at CCC Aachen</a> (in German)</li>
 </ul>
 <h2 id="blog">Blog</h2>
 <p>For more information regarding restic development, have a look at <a href="/blog">our blog</a>. The latest posts are:</p>

--- a/public/index.html
+++ b/public/index.html
@@ -170,8 +170,18 @@
 
     </div>
 
-    <a href="https://github.com/restic/restic" class="desktop">
-	<img style="position: fixed; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/38ef81f8aca64bb9a64448d0d70f1308ef5341ab/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png">
+    
+<a href="https://github.com/restic/restic" class="github-corner desktop" aria-label="View restic on GitHub">
+	<svg width="80" height="80" viewBox="0 0 250 250" style="fill:#202020; color:#fff; position: absolute; top: 0; border: 0; right: 0;" aria-hidden="true">
+		<title>View restic on GitHub</title>
+		<path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
+		<path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path>
+		<path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path>
+	</svg>
 </a>
+<style>
+	.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}
+</style>
+
   </body>
 </html>

--- a/public/index.xml
+++ b/public/index.xml
@@ -13,113 +13,91 @@
       <link>https://restic.net/blog/2023-10-29/restic-0.16.2-released/</link>
       <pubDate>Sun, 29 Oct 2023 00:00:00 +0200</pubDate>
       <guid>https://restic.net/blog/2023-10-29/restic-0.16.2-released/</guid>
-      <description>We are happy to announce the release of restic 0.16.2!
-This release restores support for ARMv5 which was accidentally not included in the previous one, and also fixes missing documentation on Read the Docs.
-To download the new release and to see a more detailed list of important changes, please head over to GitHub. If you already have restic (0.9.4 or later), you can use the self-update command to automatically download and verify the new release.</description>
+      <description>We are happy to announce the release of restic 0.16.2!&#xA;This release restores support for ARMv5 which was accidentally not included in the previous one, and also fixes missing documentation on Read the Docs.&#xA;To download the new release and to see a more detailed list of important changes, please head over to GitHub. If you already have restic (0.9.4 or later), you can use the self-update command to automatically download and verify the new release.</description>
     </item>
     <item>
       <title>Restic 0.16.1 Released</title>
       <link>https://restic.net/blog/2023-10-24/restic-0.16.1-released/</link>
       <pubDate>Tue, 24 Oct 2023 00:00:00 +0200</pubDate>
       <guid>https://restic.net/blog/2023-10-24/restic-0.16.1-released/</guid>
-      <description>We are happy to announce the release of restic 0.16.1!
-This release contains a few usage and cosmetic improvements, but also one bugfix for a very unlikely but still possible data corruption issue when using the max compression level. Please read the changelog for more details and information on how to verify your repository if you used max compression. Please also note that the auto compression level (which is the default) was never affected.</description>
+      <description>We are happy to announce the release of restic 0.16.1!&#xA;This release contains a few usage and cosmetic improvements, but also one bugfix for a very unlikely but still possible data corruption issue when using the max compression level. Please read the changelog for more details and information on how to verify your repository if you used max compression. Please also note that the auto compression level (which is the default) was never affected.</description>
     </item>
     <item>
       <title>Restic 0.16.0 Released</title>
       <link>https://restic.net/blog/2023-07-31/restic-0.16.0-released/</link>
       <pubDate>Mon, 31 Jul 2023 20:42:23 +0200</pubDate>
       <guid>https://restic.net/blog/2023-07-31/restic-0.16.0-released/</guid>
-      <description>We are happy to announce the release of restic 0.16.0!
-This version of restic brings up to 25% less memory usage and a lot of usability improvements, including &amp;lt;snapshot&amp;gt;:&amp;lt;subfolder&amp;gt; syntax for the diff, ls and restore commands, as well as a progress bar and JSON support for the restore command. Please see the documentation of each command for details.
-Restic now also includes a repair snapshots command, which can be used to salvage certain types of damaged repositories.</description>
+      <description>We are happy to announce the release of restic 0.16.0!&#xA;This version of restic brings up to 25% less memory usage and a lot of usability improvements, including &amp;lt;snapshot&amp;gt;:&amp;lt;subfolder&amp;gt; syntax for the diff, ls and restore commands, as well as a progress bar and JSON support for the restore command. Please see the documentation of each command for details.&#xA;Restic now also includes a repair snapshots command, which can be used to salvage certain types of damaged repositories.</description>
     </item>
     <item>
       <title>REST-server 0.12.1 released</title>
       <link>https://restic.net/blog/2023-07-09/rest-server-0.12.1-released/</link>
       <pubDate>Sun, 09 Jul 2023 18:00:00 +0200</pubDate>
       <guid>https://restic.net/blog/2023-07-09/rest-server-0.12.1-released/</guid>
-      <description>We have just released rest-server 0.12.1.
-This release includes a bugfix for fsync related warnings and allows logging to stdout using the --log - option. Please see the changelog for more specific information!
-Please let us know what you think in the forum post linked below!</description>
+      <description>We have just released rest-server 0.12.1.&#xA;This release includes a bugfix for fsync related warnings and allows logging to stdout using the --log - option. Please see the changelog for more specific information!&#xA;Please let us know what you think in the forum post linked below!</description>
     </item>
     <item>
       <title>REST-server 0.12.0 released</title>
       <link>https://restic.net/blog/2023-04-24/rest-server-0.12.0-released/</link>
       <pubDate>Mon, 24 Apr 2023 13:00:00 +0200</pubDate>
       <guid>https://restic.net/blog/2023-04-24/rest-server-0.12.0-released/</guid>
-      <description>We have just released rest-server 0.12.0.
-This release includes performance optimizations, allowing additional characters in usernames, ability to specify .htpasswd file location, as well as some macOS specific fixes and other general compatibility fixes. Please see the changelog for more specific information!
-Please let us know what you think in the forum post linked below!</description>
+      <description>We have just released rest-server 0.12.0.&#xA;This release includes performance optimizations, allowing additional characters in usernames, ability to specify .htpasswd file location, as well as some macOS specific fixes and other general compatibility fixes. Please see the changelog for more specific information!&#xA;Please let us know what you think in the forum post linked below!</description>
     </item>
     <item>
       <title>Restic 0.15.2 released</title>
       <link>https://restic.net/blog/2023-04-24/restic-0.15.2-released/</link>
       <pubDate>Mon, 24 Apr 2023 12:00:00 +0200</pubDate>
       <guid>https://restic.net/blog/2023-04-24/restic-0.15.2-released/</guid>
-      <description>We&amp;rsquo;re very pleased to announce restic 0.15.2!
-This release is primarily intended to address some minor bugs and cosmetic issues, but worth mentioning is that it is now possible to use the ap-southeast-4 region (Melbourne) with S3. Also, official restic builds for the riscv64 architecture on Linux are now available.
-To download the new release and to see a more detailed list of important changes, please head over to GitHub. If you already have restic (0.</description>
+      <description>We&amp;rsquo;re very pleased to announce restic 0.15.2!&#xA;This release is primarily intended to address some minor bugs and cosmetic issues, but worth mentioning is that it is now possible to use the ap-southeast-4 region (Melbourne) with S3. Also, official restic builds for the riscv64 architecture on Linux are now available.&#xA;To download the new release and to see a more detailed list of important changes, please head over to GitHub. If you already have restic (0.</description>
     </item>
     <item>
       <title>Restic 0.15.1 Released</title>
       <link>https://restic.net/blog/2023-01-30/restic-0.15.1-released/</link>
       <pubDate>Mon, 30 Jan 2023 00:00:00 +0100</pubDate>
       <guid>https://restic.net/blog/2023-01-30/restic-0.15.1-released/</guid>
-      <description>We&amp;rsquo;re very pleased to announce restic 0.15.1! This is just a small bugfix release, fixing some issues and cosmetic inconveniences.
-To download the new release and to see a more detailed list of important changes, please head over to GitHub. If you already have restic (0.9.4 or later), you can use the self-update command to automatically download and verify the new release.
-As always, thanks for reporting any issues you encounter!</description>
+      <description>We&amp;rsquo;re very pleased to announce restic 0.15.1! This is just a small bugfix release, fixing some issues and cosmetic inconveniences.&#xA;To download the new release and to see a more detailed list of important changes, please head over to GitHub. If you already have restic (0.9.4 or later), you can use the self-update command to automatically download and verify the new release.&#xA;As always, thanks for reporting any issues you encounter!</description>
     </item>
     <item>
       <title>Restic 0.15.0 Released</title>
       <link>https://restic.net/blog/2023-01-12/restic-0.15.0-released/</link>
       <pubDate>Thu, 12 Jan 2023 21:14:23 +0100</pubDate>
       <guid>https://restic.net/blog/2023-01-12/restic-0.15.0-released/</guid>
-      <description>We are happy to announce the release of restic 0.15.0!
-In this version, a new rewrite command has been implemented. This allows for removing unwanted data from existing snapshots, for example if you discover that some files were unintentionally backed up, such as files with sensitive content or files that take up a lot of space and don&amp;rsquo;t need to be backed up. Please see the corresponding documentation for more information and usage examples.</description>
+      <description>We are happy to announce the release of restic 0.15.0!&#xA;In this version, a new rewrite command has been implemented. This allows for removing unwanted data from existing snapshots, for example if you discover that some files were unintentionally backed up, such as files with sensitive content or files that take up a lot of space and don&amp;rsquo;t need to be backed up. Please see the corresponding documentation for more information and usage examples.</description>
     </item>
     <item>
       <title>Restic 0.14.0 Released</title>
       <link>https://restic.net/blog/2022-08-25/restic-0.14.0-released/</link>
       <pubDate>Thu, 25 Aug 2022 20:16:02 +0200</pubDate>
       <guid>https://restic.net/blog/2022-08-25/restic-0.14.0-released/</guid>
-      <description>We today happily announce the release of restic 0.14.0! \o/
-This release contains a highly anticipated feature in restic - compression! To start using it, either initialize a new repository (which defaults to repository version 2 and therefore supports compression) or upgrade your current repository. The compression level can be changed from the default auto (fast and efficient) to max or off using the --compression option (or the corresponding environment variable).</description>
+      <description>We today happily announce the release of restic 0.14.0! \o/&#xA;This release contains a highly anticipated feature in restic - compression! To start using it, either initialize a new repository (which defaults to repository version 2 and therefore supports compression) or upgrade your current repository. The compression level can be changed from the default auto (fast and efficient) to max or off using the --compression option (or the corresponding environment variable).</description>
     </item>
     <item>
       <title>Restic 0.13.1 Released</title>
       <link>https://restic.net/blog/2022-04-10/restic-0.13.1-released/</link>
       <pubDate>Sun, 10 Apr 2022 11:16:23 +0200</pubDate>
       <guid>https://restic.net/blog/2022-04-10/restic-0.13.1-released/</guid>
-      <description>We&amp;rsquo;re proud to announce that restic 0.13.1 has been released today!
-This release contains two smaller bug fixes which came up after the last release. For downloading the new release and to see a more detailed list of important changes, please head over to GitHub. If you already have restic (0.9.4 or later), you can use the self-update command to automatically download and verify the new release.
-As always, thanks for reporting any issues you encounter!</description>
+      <description>We&amp;rsquo;re proud to announce that restic 0.13.1 has been released today!&#xA;This release contains two smaller bug fixes which came up after the last release. For downloading the new release and to see a more detailed list of important changes, please head over to GitHub. If you already have restic (0.9.4 or later), you can use the self-update command to automatically download and verify the new release.&#xA;As always, thanks for reporting any issues you encounter!</description>
     </item>
     <item>
       <title>Restic 0.13.0 Released</title>
       <link>https://restic.net/blog/2022-03-26/restic-0.13.0-released/</link>
       <pubDate>Sat, 26 Mar 2022 19:47:44 +0100</pubDate>
       <guid>https://restic.net/blog/2022-03-26/restic-0.13.0-released/</guid>
-      <description>We&amp;rsquo;re proud to announce that restic 0.13.0 has been released today!
-This release contains several bug fixes and improvements worth mentioning:
-It is now possible to add negative patterns to cancel previous exclusions (e.g. --exclude &#39;/home/user/*&#39; --exclude &#39;!/home/user/.config&#39;). The backup command now has a --dry-run switch which (together with --verbose) prints the files that would be included in a backup. We have added checksums for various backends so data uploaded to a backend can be checked there.</description>
+      <description>We&amp;rsquo;re proud to announce that restic 0.13.0 has been released today!&#xA;This release contains several bug fixes and improvements worth mentioning:&#xA;It is now possible to add negative patterns to cancel previous exclusions (e.g. --exclude &#39;/home/user/*&#39; --exclude &#39;!/home/user/.config&#39;). The backup command now has a --dry-run switch which (together with --verbose) prints the files that would be included in a backup. We have added checksums for various backends so data uploaded to a backend can be checked there.</description>
     </item>
     <item>
       <title>Rest Server 0.11.0 released</title>
       <link>https://restic.net/blog/2022-02-10/rest-server-0.11.0-released/</link>
       <pubDate>Thu, 10 Feb 2022 20:23:36 +0100</pubDate>
       <guid>https://restic.net/blog/2022-02-10/rest-server-0.11.0-released/</guid>
-      <description>We have just released rest-server 0.11.0. It includes a fix for an issue where during transfer, a file could have been corrupted. The details are described in PR #142. The full changelog is included in the release.
-Please let us know what you think in the forum post linked below!</description>
+      <description>We have just released rest-server 0.11.0. It includes a fix for an issue where during transfer, a file could have been corrupted. The details are described in PR #142. The full changelog is included in the release.&#xA;Please let us know what you think in the forum post linked below!</description>
     </item>
     <item>
       <title>Restic 0.12.1 released</title>
       <link>https://restic.net/blog/2021-08-03/restic-0.12.1-released/</link>
       <pubDate>Tue, 03 Aug 2021 12:04:36 +0200</pubDate>
       <guid>https://restic.net/blog/2021-08-03/restic-0.12.1-released/</guid>
-      <description>We&amp;rsquo;re proud to announce that restic 0.12.1 has been released today! This release contains several small fixes for bugs and a few smaller enhancements.
-For downloading the new release and to see a more detailed list of important changes, please head over to GitHub. If you already have restic (0.9.4 or later), you can use the self-update command to automatically download and verify the new release.
-As always, thanks for reporting any issues you encounter!</description>
+      <description>We&amp;rsquo;re proud to announce that restic 0.12.1 has been released today! This release contains several small fixes for bugs and a few smaller enhancements.&#xA;For downloading the new release and to see a more detailed list of important changes, please head over to GitHub. If you already have restic (0.9.4 or later), you can use the self-update command to automatically download and verify the new release.&#xA;As always, thanks for reporting any issues you encounter!</description>
     </item>
     <item>
       <title>Restic 0.12.0 released</title>
@@ -133,66 +111,56 @@ As always, thanks for reporting any issues you encounter!</description>
       <link>https://restic.net/blog/2020-11-05/restic-0.11.0-released/</link>
       <pubDate>Thu, 05 Nov 2020 10:00:51 +0100</pubDate>
       <guid>https://restic.net/blog/2020-11-05/restic-0.11.0-released/</guid>
-      <description>Restic 0.11.0 was released today! For downloading the new release and to see a more detailed list of important changes, please head over to GitHub. If you already have restic (0.9.4 or later), you can use the self-update command to automatically download and verify the new release.
-This new release contains a highly anticipated feature on Windows: being able to automatically create a Volume Shadow Copy (VSS) using restic backup --use-fs-snapshot.</description>
+      <description>Restic 0.11.0 was released today! For downloading the new release and to see a more detailed list of important changes, please head over to GitHub. If you already have restic (0.9.4 or later), you can use the self-update command to automatically download and verify the new release.&#xA;This new release contains a highly anticipated feature on Windows: being able to automatically create a Volume Shadow Copy (VSS) using restic backup --use-fs-snapshot.</description>
     </item>
     <item>
       <title>restic 0.10.0 released</title>
       <link>https://restic.net/blog/2020-09-19/restic-0.10.0-released/</link>
       <pubDate>Sat, 19 Sep 2020 17:44:59 +0200</pubDate>
       <guid>https://restic.net/blog/2020-09-19/restic-0.10.0-released/</guid>
-      <description>After ten months of work we&amp;rsquo;ve just released restic 0.10.0! For downloading the new release and to see a more detailed list of important changes, please head over to GitHub. If you already have restic (0.9.4 or later), you can use the self-update command to automatically download and verify the new release.
-This release contains a lot of improvements, both smaller and bigger ones, and the restic project wishes to send a big thank you to everyone who contributed to make this happen.</description>
+      <description>After ten months of work we&amp;rsquo;ve just released restic 0.10.0! For downloading the new release and to see a more detailed list of important changes, please head over to GitHub. If you already have restic (0.9.4 or later), you can use the self-update command to automatically download and verify the new release.&#xA;This release contains a lot of improvements, both smaller and bigger ones, and the restic project wishes to send a big thank you to everyone who contributed to make this happen.</description>
     </item>
     <item>
       <title>Rest Server 0.10.0 Released</title>
       <link>https://restic.net/blog/2020-09-13/rest-server-0.10.0-released/</link>
       <pubDate>Sun, 13 Sep 2020 11:47:00 +0200</pubDate>
       <guid>https://restic.net/blog/2020-09-13/rest-server-0.10.0-released/</guid>
-      <description>We have just released rest-server 0.10.0 which includes a few potentially breaking changes. For details, please see the changes described in the release.
-This release corrects a security issue. User wojas discovered that it was possible to access repositories belonging to other users. It was not possible to access directories outside of the path the repositories were stored in.
-The rest-server has an option to allow users (identify by HTTP Basic authentication) to only access their own repository by specifying the --private-repos option.</description>
+      <description>We have just released rest-server 0.10.0 which includes a few potentially breaking changes. For details, please see the changes described in the release.&#xA;This release corrects a security issue. User wojas discovered that it was possible to access repositories belonging to other users. It was not possible to access directories outside of the path the repositories were stored in.&#xA;The rest-server has an option to allow users (identify by HTTP Basic authentication) to only access their own repository by specifying the --private-repos option.</description>
     </item>
     <item>
       <title>restic 0.9.6 released</title>
       <link>https://restic.net/blog/2019-11-22/restic-0.9.6-released/</link>
       <pubDate>Fri, 22 Nov 2019 00:00:00 +0000</pubDate>
       <guid>https://restic.net/blog/2019-11-22/restic-0.9.6-released/</guid>
-      <description>We&amp;rsquo;ve just released restic 0.9.6. For downloading the new release and see a more detailed list of important changes, head over to GitHub. If you already have restic (0.9.4 or later), you can use the self-update command to automatically download and verify the new release.
-As always, thanks for reporting any issues you encounter! Or just write a post in the forum.</description>
+      <description>We&amp;rsquo;ve just released restic 0.9.6. For downloading the new release and see a more detailed list of important changes, head over to GitHub. If you already have restic (0.9.4 or later), you can use the self-update command to automatically download and verify the new release.&#xA;As always, thanks for reporting any issues you encounter! Or just write a post in the forum.</description>
     </item>
     <item>
       <title>restic 0.9.5 released</title>
       <link>https://restic.net/blog/2019-04-23/restic-0.9.5-released/</link>
       <pubDate>Tue, 23 Apr 2019 00:00:00 +0000</pubDate>
       <guid>https://restic.net/blog/2019-04-23/restic-0.9.5-released/</guid>
-      <description>We&amp;rsquo;ve just released restic 0.9.5. For downloading the new release and see a more detailed list of important changes, head over to GitHub. If you already have restic 0.9.4, you can use the self-update command to automatically download and verify the new release.
-As always, thanks for reporting any issues you encounter! Or just write a post in the forum.</description>
+      <description>We&amp;rsquo;ve just released restic 0.9.5. For downloading the new release and see a more detailed list of important changes, head over to GitHub. If you already have restic 0.9.4, you can use the self-update command to automatically download and verify the new release.&#xA;As always, thanks for reporting any issues you encounter! Or just write a post in the forum.</description>
     </item>
     <item>
       <title>restic 0.9.4 released</title>
       <link>https://restic.net/blog/2019-01-06/restic-0.9.4-released/</link>
       <pubDate>Sun, 06 Jan 2019 00:00:00 +0000</pubDate>
       <guid>https://restic.net/blog/2019-01-06/restic-0.9.4-released/</guid>
-      <description>We&amp;rsquo;ve just released restic 0.9.4. Besides several fixes for bugs it contains a new restorer implementation which downloads data concurrently, so it is much faster than the old one.
-For downloading the new release and see a more detailed list of important changes, head over to GitHub. If you already have restic 0.9.3, you can use the self-update command to automatically download and verify the new release. Due to a bug you need to specify where restic should write the new file, e.</description>
+      <description>We&amp;rsquo;ve just released restic 0.9.4. Besides several fixes for bugs it contains a new restorer implementation which downloads data concurrently, so it is much faster than the old one.&#xA;For downloading the new release and see a more detailed list of important changes, head over to GitHub. If you already have restic 0.9.3, you can use the self-update command to automatically download and verify the new release. Due to a bug you need to specify where restic should write the new file, e.</description>
     </item>
     <item>
       <title>New Year, New Infrastructure!</title>
       <link>https://restic.net/blog/2019-01-01/new-infrastructure/</link>
       <pubDate>Tue, 01 Jan 2019 00:00:00 +0000</pubDate>
       <guid>https://restic.net/blog/2019-01-01/new-infrastructure/</guid>
-      <description>We wish you a happy new year 2019!
-Our friends at hosting.de recently provided us with a dedicated server to host this website, the forum, and the beta builder for restic, and we&amp;rsquo;ve just moved everything over. Thank you very much for your support!
-Please leave a comment in the forum in the thread for this announcement if there&amp;rsquo;s anything broken for you.</description>
+      <description>We wish you a happy new year 2019!&#xA;Our friends at hosting.de recently provided us with a dedicated server to host this website, the forum, and the beta builder for restic, and we&amp;rsquo;ve just moved everything over. Thank you very much for your support!&#xA;Please leave a comment in the forum in the thread for this announcement if there&amp;rsquo;s anything broken for you.</description>
     </item>
     <item>
       <title>restic 0.9.3 released</title>
       <link>https://restic.net/blog/2018-10-13/restic-0.9.3-released/</link>
       <pubDate>Sat, 13 Oct 2018 00:00:00 +0000</pubDate>
       <guid>https://restic.net/blog/2018-10-13/restic-0.9.3-released/</guid>
-      <description>We&amp;rsquo;ve just released restic 0.9.3. It is mostly a maintenance release, but several smaller enhancements have been added.
-For downloading the new release and see a more detailed list of important changes, head over to GitHub. As always, thanks for reporting any issues you encounter! Or just write a post in the forum.</description>
+      <description>We&amp;rsquo;ve just released restic 0.9.3. It is mostly a maintenance release, but several smaller enhancements have been added.&#xA;For downloading the new release and see a more detailed list of important changes, head over to GitHub. As always, thanks for reporting any issues you encounter! Or just write a post in the forum.</description>
     </item>
     <item>
       <title>Configuring GitHub Issue Templates</title>
@@ -206,150 +174,126 @@ For downloading the new release and see a more detailed list of important change
       <link>https://restic.net/blog/2018-09-02/travis-build-cache/</link>
       <pubDate>Sun, 02 Sep 2018 00:00:00 +0000</pubDate>
       <guid>https://restic.net/blog/2018-09-02/travis-build-cache/</guid>
-      <description>The restic project runs the unit and integration tests for each pushed commit and each pull request. We&amp;rsquo;re using Travis CI for Linux and OS X, and AppVeyor for Windows. We&amp;rsquo;re very grateful that they provide their services free of charge for Open Source projects!
-Our project not only runs the tests on Travis, but also compiles restic for each supported architecture, operating system, and version of Go. Go is known for its fast compilation times, but still, compilation takes its time.</description>
+      <description>The restic project runs the unit and integration tests for each pushed commit and each pull request. We&amp;rsquo;re using Travis CI for Linux and OS X, and AppVeyor for Windows. We&amp;rsquo;re very grateful that they provide their services free of charge for Open Source projects!&#xA;Our project not only runs the tests on Travis, but also compiles restic for each supported architecture, operating system, and version of Go. Go is known for its fast compilation times, but still, compilation takes its time.</description>
     </item>
     <item>
       <title>restic 0.9.2 released</title>
       <link>https://restic.net/blog/2018-08-06/restic-0.9.2-released/</link>
       <pubDate>Mon, 06 Aug 2018 00:00:00 +0000</pubDate>
       <guid>https://restic.net/blog/2018-08-06/restic-0.9.2-released/</guid>
-      <description>We&amp;rsquo;ve just released restic 0.9.2. Among several fixes it includes support for &amp;ldquo;Application Keys&amp;rdquo; for BackBlaze B2, which can be restricted to a specific bucket and/or path (so you don&amp;rsquo;t have to give restic access to all your files stored at B2).
-For downloading the new release and see a more detailed list of important changes, head over to GitHub. As always, thanks for reporting any issues you encounter! Or just write a post in the forum.</description>
+      <description>We&amp;rsquo;ve just released restic 0.9.2. Among several fixes it includes support for &amp;ldquo;Application Keys&amp;rdquo; for BackBlaze B2, which can be restricted to a specific bucket and/or path (so you don&amp;rsquo;t have to give restic access to all your files stored at B2).&#xA;For downloading the new release and see a more detailed list of important changes, head over to GitHub. As always, thanks for reporting any issues you encounter! Or just write a post in the forum.</description>
     </item>
     <item>
       <title>restic 0.9.1 released</title>
       <link>https://restic.net/blog/2018-06-10/restic-0.9.1-released/</link>
       <pubDate>Sun, 10 Jun 2018 00:00:00 +0000</pubDate>
       <guid>https://restic.net/blog/2018-06-10/restic-0.9.1-released/</guid>
-      <description>We&amp;rsquo;ve just released restic 0.9.1, a minor bugfix release.
-For downloading the new release and see a more detailed list of important changes, head over to GitHub. As always, thanks for reporting any issues you encounter! Or just write a post in the forum.</description>
+      <description>We&amp;rsquo;ve just released restic 0.9.1, a minor bugfix release.&#xA;For downloading the new release and see a more detailed list of important changes, head over to GitHub. As always, thanks for reporting any issues you encounter! Or just write a post in the forum.</description>
     </item>
     <item>
       <title>restic 0.9.0 released</title>
       <link>https://restic.net/blog/2018-05-21/restic-0.9.0-released/</link>
       <pubDate>Mon, 21 May 2018 00:00:00 +0000</pubDate>
       <guid>https://restic.net/blog/2018-05-21/restic-0.9.0-released/</guid>
-      <description>We&amp;rsquo;ve just released restic 0.9.0. This is the next bigger release since 0.8.0, it mainly brings a completely rewritten archiver core, improves the speed for restic check, and many bug fixes.
-For downloading the new release and see a more detailed list of important changes, head over to GitHub. As always, thanks for reporting any issues you encounter! Or just write a post in the forum.</description>
+      <description>We&amp;rsquo;ve just released restic 0.9.0. This is the next bigger release since 0.8.0, it mainly brings a completely rewritten archiver core, improves the speed for restic check, and many bug fixes.&#xA;For downloading the new release and see a more detailed list of important changes, head over to GitHub. As always, thanks for reporting any issues you encounter! Or just write a post in the forum.</description>
     </item>
     <item>
       <title>The restic project turns four!</title>
       <link>https://restic.net/blog/2018-04-06/restic-turns-four/</link>
       <pubDate>Fri, 06 Apr 2018 00:00:00 +0000</pubDate>
       <guid>https://restic.net/blog/2018-04-06/restic-turns-four/</guid>
-      <description>Four years ago on 2014-04-06 fd0 added the first commit to what would later become the restic repository. At the time it was code-named khepri, but unfortunately the name wasn&amp;rsquo;t available on GitHub any more, so we had to find a different one.
-At the moment, restic&amp;rsquo;s repository was starred on GitHub almost four thousand times. And we&amp;rsquo;ve collected 56 other backup tools along the way, helping countless people to discover backup programs (not necessarily restic alone).</description>
+      <description>Four years ago on 2014-04-06 fd0 added the first commit to what would later become the restic repository. At the time it was code-named khepri, but unfortunately the name wasn&amp;rsquo;t available on GitHub any more, so we had to find a different one.&#xA;At the moment, restic&amp;rsquo;s repository was starred on GitHub almost four thousand times. And we&amp;rsquo;ve collected 56 other backup tools along the way, helping countless people to discover backup programs (not necessarily restic alone).</description>
     </item>
     <item>
       <title>Using rclone as a restic Backend</title>
       <link>https://restic.net/blog/2018-04-01/rclone-backend/</link>
       <pubDate>Sun, 01 Apr 2018 00:00:00 +0000</pubDate>
       <guid>https://restic.net/blog/2018-04-01/rclone-backend/</guid>
-      <description>Originally, restic started with just two backends: local and sftp. Over time, many new backends were added so that restic is now able to store a repository on a variety of different cloud-based services. However, it became clear that each new backend we add for a new cloud service works slightly different and requires almost constant maintenance.
-A while ago, Alex was contacted by Nick, who found restic by listening to the episode #48 of the GoTime podcast.</description>
+      <description>Originally, restic started with just two backends: local and sftp. Over time, many new backends were added so that restic is now able to store a repository on a variety of different cloud-based services. However, it became clear that each new backend we add for a new cloud service works slightly different and requires almost constant maintenance.&#xA;A while ago, Alex was contacted by Nick, who found restic by listening to the episode #48 of the GoTime podcast.</description>
     </item>
     <item>
       <title>restic 0.8.3 released</title>
       <link>https://restic.net/blog/2018-02-26/restic-0.8.3-released/</link>
       <pubDate>Mon, 26 Feb 2018 00:00:00 +0000</pubDate>
       <guid>https://restic.net/blog/2018-02-26/restic-0.8.3-released/</guid>
-      <description>We&amp;rsquo;ve just released restic 0.8.3. This is again a bugfix release, but also several improvements for cloud-based backends.
-For downloading the new release and see a more detailed list of important changes, head over to GitHub. As always, thanks for reporting any issues you encounter! Or just write a post in the forum.</description>
+      <description>We&amp;rsquo;ve just released restic 0.8.3. This is again a bugfix release, but also several improvements for cloud-based backends.&#xA;For downloading the new release and see a more detailed list of important changes, head over to GitHub. As always, thanks for reporting any issues you encounter! Or just write a post in the forum.</description>
     </item>
     <item>
       <title>restic 0.8.2 released</title>
       <link>https://restic.net/blog/2018-02-17/restic-0.8.2-released/</link>
       <pubDate>Sat, 17 Feb 2018 00:00:00 +0000</pubDate>
       <guid>https://restic.net/blog/2018-02-17/restic-0.8.2-released/</guid>
-      <description>We&amp;rsquo;ve just released restic 0.8.2. This is mostly a bugfix release, with some smaller enhancements.
-For downloading the new release and see a more detailed list of important changes, head over to GitHub. As always, thanks for reporting any issues you encounter! Or just write a post in the forum.</description>
+      <description>We&amp;rsquo;ve just released restic 0.8.2. This is mostly a bugfix release, with some smaller enhancements.&#xA;For downloading the new release and see a more detailed list of important changes, head over to GitHub. As always, thanks for reporting any issues you encounter! Or just write a post in the forum.</description>
     </item>
     <item>
       <title>moving to restic.net</title>
       <link>https://restic.net/blog/2018-01-01/moving-domain/</link>
       <pubDate>Mon, 01 Jan 2018 00:00:00 +0000</pubDate>
       <guid>https://restic.net/blog/2018-01-01/moving-domain/</guid>
-      <description>A while back we&amp;rsquo;ve registered the domain restic.net and we&amp;rsquo;re moving the website from GitHub Pages to a dedicated hosting machine at https://restic.net. Please update any links to the old website, thanks!
-If you&amp;rsquo;re subscribed to the RSS/Atom XML feed, you need to update the feed url to https://restic.net/feed.xml.
-Update: When we migrated the website to Hugo in 2020, the feed changed from Atom at the above mentioned URL to RSS 2.</description>
+      <description>A while back we&amp;rsquo;ve registered the domain restic.net and we&amp;rsquo;re moving the website from GitHub Pages to a dedicated hosting machine at https://restic.net. Please update any links to the old website, thanks!&#xA;If you&amp;rsquo;re subscribed to the RSS/Atom XML feed, you need to update the feed url to https://restic.net/feed.xml.&#xA;Update: When we migrated the website to Hugo in 2020, the feed changed from Atom at the above mentioned URL to RSS 2.</description>
     </item>
     <item>
       <title>restic 0.8.1 released</title>
       <link>https://restic.net/blog/2017-12-27/restic-0.8.1-released/</link>
       <pubDate>Wed, 27 Dec 2017 00:00:00 +0000</pubDate>
       <guid>https://restic.net/blog/2017-12-27/restic-0.8.1-released/</guid>
-      <description>We&amp;rsquo;ve just released restic 0.8.1. Among others, support for DigitalOcean Spaces (and other backends which use HTTP) is improved.
-For downloading the new release and see a more detailed list of important changes, head over to GitHub. As always, thanks for reporting any issues you encounter! Or just write a post in the forum.</description>
+      <description>We&amp;rsquo;ve just released restic 0.8.1. Among others, support for DigitalOcean Spaces (and other backends which use HTTP) is improved.&#xA;For downloading the new release and see a more detailed list of important changes, head over to GitHub. As always, thanks for reporting any issues you encounter! Or just write a post in the forum.</description>
     </item>
     <item>
       <title>restic 0.8.0 released</title>
       <link>https://restic.net/blog/2017-11-26/restic-0.8.0-released/</link>
       <pubDate>Sun, 26 Nov 2017 00:00:00 +0000</pubDate>
       <guid>https://restic.net/blog/2017-11-26/restic-0.8.0-released/</guid>
-      <description>We&amp;rsquo;ve just released restic 0.8.0. It brings the new awesome metadata cache which will speed up many operations, you may need to run restic prune once to fully see it in action.
-For downloading the new release and see a more detailed list of important changes, head over to GitHub. As always, thanks for reporting any issues you encounter! Or just write a post in the forum.
-This release also corrects a (low risk) vulnerability.</description>
+      <description>We&amp;rsquo;ve just released restic 0.8.0. It brings the new awesome metadata cache which will speed up many operations, you may need to run restic prune once to fully see it in action.&#xA;For downloading the new release and see a more detailed list of important changes, head over to GitHub. As always, thanks for reporting any issues you encounter! Or just write a post in the forum.&#xA;This release also corrects a (low risk) vulnerability.</description>
     </item>
     <item>
       <title>Upcoming changes for the S3 backend</title>
       <link>https://restic.net/blog/2017-11-25/upcoming-changes-to-s3/</link>
       <pubDate>Sat, 25 Nov 2017 00:00:00 +0000</pubDate>
       <guid>https://restic.net/blog/2017-11-25/upcoming-changes-to-s3/</guid>
-      <description>TL;DR: If you&amp;rsquo;re using the s3 backend and cannot access your repo any more, append the path /restic to the repository location.
-We&amp;rsquo;ve just merged Pull Request #1437 which resolves an issue with the S3 backend reported in #1292. When the next restic version is released (or you&amp;rsquo;re using the master branch directly), this may require modifying the repository location you&amp;rsquo;re passing to restic.
-In order to access a repository stored on S3, restic requires the following information:</description>
+      <description>TL;DR: If you&amp;rsquo;re using the s3 backend and cannot access your repo any more, append the path /restic to the repository location.&#xA;We&amp;rsquo;ve just merged Pull Request #1437 which resolves an issue with the S3 backend reported in #1292. When the next restic version is released (or you&amp;rsquo;re using the master branch directly), this may require modifying the repository location you&amp;rsquo;re passing to restic.&#xA;In order to access a repository stored on S3, restic requires the following information:</description>
     </item>
     <item>
       <title>restic 0.7.3 released</title>
       <link>https://restic.net/blog/2017-09-20/restic-0.7.3-released/</link>
       <pubDate>Wed, 20 Sep 2017 00:00:00 +0000</pubDate>
       <guid>https://restic.net/blog/2017-09-20/restic-0.7.3-released/</guid>
-      <description>We&amp;rsquo;ve just released restic 0.7.3 to correct a bug with the Google Cloud Storage and Azure backends. When restic prune or restic rebuild-index was run, not all files stored in these backends were considered.
-For downloading the code, head over to GitHub. As always, thanks for reporting any issues you encounter!
-The binaries released with each restic version are reproducible, which means that you can easily reproduce a byte identical version from the source code for that release.</description>
+      <description>We&amp;rsquo;ve just released restic 0.7.3 to correct a bug with the Google Cloud Storage and Azure backends. When restic prune or restic rebuild-index was run, not all files stored in these backends were considered.&#xA;For downloading the code, head over to GitHub. As always, thanks for reporting any issues you encounter!&#xA;The binaries released with each restic version are reproducible, which means that you can easily reproduce a byte identical version from the source code for that release.</description>
     </item>
     <item>
       <title>restic 0.7.2 released</title>
       <link>https://restic.net/blog/2017-09-13/restic-0.7.2-released/</link>
       <pubDate>Wed, 13 Sep 2017 00:00:00 +0000</pubDate>
       <guid>https://restic.net/blog/2017-09-13/restic-0.7.2-released/</guid>
-      <description>We&amp;rsquo;re very pleased to announce that restic 0.7.2 has been released! For downloading the code, head over to GitHub. As always, thanks for reporting any issues you encounter!
-The binaries released with each restic version are reproducible, which means that you can easily reproduce a byte identical version from the source code for that release. Instructions on how to do that are contained in the builder repository.
-Important Changes in 0.</description>
+      <description>We&amp;rsquo;re very pleased to announce that restic 0.7.2 has been released! For downloading the code, head over to GitHub. As always, thanks for reporting any issues you encounter!&#xA;The binaries released with each restic version are reproducible, which means that you can easily reproduce a byte identical version from the source code for that release. Instructions on how to do that are contained in the builder repository.&#xA;Important Changes in 0.</description>
     </item>
     <item>
       <title>Meeting at FrOSCon 2017 - Details</title>
       <link>https://restic.net/blog/2017-08-14/FrOSCon-Bonn-Details/</link>
       <pubDate>Mon, 14 Aug 2017 00:00:00 +0000</pubDate>
       <guid>https://restic.net/blog/2017-08-14/FrOSCon-Bonn-Details/</guid>
-      <description>As announced a few weeks ago we&amp;rsquo;re meeting at this year&amp;rsquo;s FrOSCon on 19 August 2017, 15:00 CEST in Sankt Augustin near Bonn/Cologne in Germany (free entry)! We&amp;rsquo;ll get a project room for the afternoon, the room number will be announced as an update to this blog entry, on Twitter and in the forum.
-It&amp;rsquo;d be nice to know how many of you will be able to join us, so please leave a comment in the GitHub issue #1110 or in the forum.</description>
+      <description>As announced a few weeks ago we&amp;rsquo;re meeting at this year&amp;rsquo;s FrOSCon on 19 August 2017, 15:00 CEST in Sankt Augustin near Bonn/Cologne in Germany (free entry)! We&amp;rsquo;ll get a project room for the afternoon, the room number will be announced as an update to this blog entry, on Twitter and in the forum.&#xA;It&amp;rsquo;d be nice to know how many of you will be able to join us, so please leave a comment in the GitHub issue #1110 or in the forum.</description>
     </item>
     <item>
       <title>Discourse Forum</title>
       <link>https://restic.net/blog/2017-08-11/discourse-forum/</link>
       <pubDate>Fri, 11 Aug 2017 00:00:00 +0000</pubDate>
       <guid>https://restic.net/blog/2017-08-11/discourse-forum/</guid>
-      <description>We&amp;rsquo;ve noticed that there are many questions raised as issues on GitHub, so we&amp;rsquo;ve installed a Discourse forum at https://forum.restic.net! For now, this is an experiment to see if a forum is better suited to answer questions. We&amp;rsquo;ll see how that goes.
-Please let us know any feedback you have (in the forum, obviously)!</description>
+      <description>We&amp;rsquo;ve noticed that there are many questions raised as issues on GitHub, so we&amp;rsquo;ve installed a Discourse forum at https://forum.restic.net! For now, this is an experiment to see if a forum is better suited to answer questions. We&amp;rsquo;ll see how that goes.&#xA;Please let us know any feedback you have (in the forum, obviously)!</description>
     </item>
     <item>
       <title>Please upgrade to restic 0.7.1!</title>
       <link>https://restic.net/blog/2017-07-25/please-upgrade-to-0.7.1/</link>
       <pubDate>Tue, 25 Jul 2017 00:00:00 +0000</pubDate>
       <guid>https://restic.net/blog/2017-07-25/please-upgrade-to-0.7.1/</guid>
-      <description>TL;DR:
-Under some circumstances, data in the repo was not stored properly This could have caused incomplete backups Upgrade restic to at least 0.7.1 and run restic rebuild-index before the next backup It is good practice to run restic check regularly Background We always knew that at some point there may be a more serious bug in restic that warrants a broader announcement. This is the story of how a small improvement that makes the code even more conservative lead to a small error which then caused a couple of unintended consequences.</description>
+      <description>TL;DR:&#xA;Under some circumstances, data in the repo was not stored properly This could have caused incomplete backups Upgrade restic to at least 0.7.1 and run restic rebuild-index before the next backup It is good practice to run restic check regularly Background We always knew that at some point there may be a more serious bug in restic that warrants a broader announcement. This is the story of how a small improvement that makes the code even more conservative lead to a small error which then caused a couple of unintended consequences.</description>
     </item>
     <item>
       <title>restic 0.7.1 released</title>
       <link>https://restic.net/blog/2017-07-22/restic-0.7.1-released/</link>
       <pubDate>Sat, 22 Jul 2017 00:00:00 +0000</pubDate>
       <guid>https://restic.net/blog/2017-07-22/restic-0.7.1-released/</guid>
-      <description>We&amp;rsquo;re proud to present restic 0.7.1! For downloading the code, head over to GitHub. As always, thanks for reporting any issues you encounter!
-The binaries released with each restic version starting are reproducible, which means that you can easily reproduce a byte identical version from the source code for that release. Instructions on how to do that are contained in the builder repository.
-Important Changes in 0.7.1 The migrate command for changing the s3legacy layout to the default layout for s3 backends has been improved: It can now be restarted with restic migrate --force s3_layout and automatically retries operations on error.</description>
+      <description>We&amp;rsquo;re proud to present restic 0.7.1! For downloading the code, head over to GitHub. As always, thanks for reporting any issues you encounter!&#xA;The binaries released with each restic version starting are reproducible, which means that you can easily reproduce a byte identical version from the source code for that release. Instructions on how to do that are contained in the builder repository.&#xA;Important Changes in 0.7.1 The migrate command for changing the s3legacy layout to the default layout for s3 backends has been improved: It can now be restarted with restic migrate --force s3_layout and automatically retries operations on error.</description>
     </item>
     <item>
       <title>Meeting at FrOSCon 2017</title>
@@ -363,64 +307,49 @@ Important Changes in 0.7.1 The migrate command for changing the s3legacy layout 
       <link>https://restic.net/blog/2017-07-01/restic-0.7.0-released/</link>
       <pubDate>Sat, 01 Jul 2017 00:00:00 +0000</pubDate>
       <guid>https://restic.net/blog/2017-07-01/restic-0.7.0-released/</guid>
-      <description>We&amp;rsquo;ve just released restic 0.7.0! For downloading the code, head over to GitHub. As always, thanks for reporting any issues you encounter!
-Important Changes in 0.7.0 New &amp;ldquo;swift&amp;rdquo; backend: A new backend for the OpenStack Swift cloud storage protocol has been added, https://wiki.openstack.org/wiki/Swift https://github.com/restic/restic/pull/975 https://github.com/restic/restic/pull/648
-New &amp;ldquo;b2&amp;rdquo; backend: A new backend for Backblaze B2 cloud storage service has been added, https://www.backblaze.com https://github.com/restic/restic/issues/512 https://github.com/restic/restic/pull/978
-Improved performance for the find command: Restic recognizes paths it has already checked for the files in question, so the number of backend requests is reduced a lot.</description>
+      <description>We&amp;rsquo;ve just released restic 0.7.0! For downloading the code, head over to GitHub. As always, thanks for reporting any issues you encounter!&#xA;Important Changes in 0.7.0 New &amp;ldquo;swift&amp;rdquo; backend: A new backend for the OpenStack Swift cloud storage protocol has been added, https://wiki.openstack.org/wiki/Swift https://github.com/restic/restic/pull/975 https://github.com/restic/restic/pull/648&#xA;New &amp;ldquo;b2&amp;rdquo; backend: A new backend for Backblaze B2 cloud storage service has been added, https://www.backblaze.com https://github.com/restic/restic/issues/512 https://github.com/restic/restic/pull/978&#xA;Improved performance for the find command: Restic recognizes paths it has already checked for the files in question, so the number of backend requests is reduced a lot.</description>
     </item>
     <item>
       <title>restic on GoTime #48</title>
       <link>https://restic.net/blog/2017-06-01/restic-on-gotime/</link>
       <pubDate>Thu, 01 Jun 2017 00:00:00 +0000</pubDate>
       <guid>https://restic.net/blog/2017-06-01/restic-on-gotime/</guid>
-      <description>Last week Alex had the honour to join Ashley, Erik, and Brian at GoTime. GoTime is a podcast about Go, the community, and everything in between. It was a lot of fun (and he got to do the intro in German). The episode can be found on the website, you can also listen to it right here:
-Go Time 48: Restic and Backups (Done Right) with Alexander Neumann – Listen on Changelog.</description>
+      <description>Last week Alex had the honour to join Ashley, Erik, and Brian at GoTime. GoTime is a podcast about Go, the community, and everything in between. It was a lot of fun (and he got to do the intro in German). The episode can be found on the website, you can also listen to it right here:&#xA;Go Time 48: Restic and Backups (Done Right) with Alexander Neumann – Listen on Changelog.</description>
     </item>
     <item>
       <title>restic 0.6.0 released</title>
       <link>https://restic.net/blog/2017-05-29/restic-0.6.0-released/</link>
       <pubDate>Mon, 29 May 2017 00:00:00 +0000</pubDate>
       <guid>https://restic.net/blog/2017-05-29/restic-0.6.0-released/</guid>
-      <description>We&amp;rsquo;ve just released restic 0.6.0!
-No grave bugs have been found, so the final version is identical to the -rc.1 version. This release contains many bug fixes and several improvements for the user interface, the most important changes are listed below (and also contained in the CHANGELOG.md.
-For downloading the code, head over to https://github.com/restic/restic/releases/tag/v0.6.0. As always, thanks for reporting any issues you encounter!
-Important Changes in 0.6.0 Consistent forget policy The forget command was corrected to be more consistent in which snapshots are to be forgotten.</description>
+      <description>We&amp;rsquo;ve just released restic 0.6.0!&#xA;No grave bugs have been found, so the final version is identical to the -rc.1 version. This release contains many bug fixes and several improvements for the user interface, the most important changes are listed below (and also contained in the CHANGELOG.md.&#xA;For downloading the code, head over to https://github.com/restic/restic/releases/tag/v0.6.0. As always, thanks for reporting any issues you encounter!&#xA;Important Changes in 0.6.0 Consistent forget policy The forget command was corrected to be more consistent in which snapshots are to be forgotten.</description>
     </item>
     <item>
       <title>restic 0.6.1 released</title>
       <link>https://restic.net/blog/2017-05-29/restic-0.6.1-released/</link>
       <pubDate>Mon, 29 May 2017 00:00:00 +0000</pubDate>
       <guid>https://restic.net/blog/2017-05-29/restic-0.6.1-released/</guid>
-      <description>We&amp;rsquo;ve just released restic 0.6.1!
-Just a few days after the release of restic 0.6.0 we&amp;rsquo;ve released 0.6.1 as a bugfix release to address two annoying bugs. The changes are listed below.
-This is the first release of restic that uses the new build Docker container which allows you to reproduce a byte identical version of the released binaries. This is called Reproducible Builds.
-For downloading the code, head over to GitHub.</description>
+      <description>We&amp;rsquo;ve just released restic 0.6.1!&#xA;Just a few days after the release of restic 0.6.0 we&amp;rsquo;ve released 0.6.1 as a bugfix release to address two annoying bugs. The changes are listed below.&#xA;This is the first release of restic that uses the new build Docker container which allows you to reproduce a byte identical version of the released binaries. This is called Reproducible Builds.&#xA;For downloading the code, head over to GitHub.</description>
     </item>
     <item>
       <title>restic 0.6.0-rc.1 released</title>
       <link>https://restic.net/blog/2017-05-25/restic-0.6.0-rc.1-released/</link>
       <pubDate>Thu, 25 May 2017 00:00:00 +0000</pubDate>
       <guid>https://restic.net/blog/2017-05-25/restic-0.6.0-rc.1-released/</guid>
-      <description>We&amp;rsquo;ve just released restic 0.6.0-rc.1!
-This is the Release Candidate version. If no grave bugs occur, it will be released as the final version in a few days. This release contains many bug fixes and several improvements for the user interface, the most important changes are listed below (and also contained in the CHANGELOG.md.
-For downloading the code, head over to https://github.com/restic/restic/releases/tag/v0.6.0-rc.1 As always, thanks for reporting any issues you encounter!</description>
+      <description>We&amp;rsquo;ve just released restic 0.6.0-rc.1!&#xA;This is the Release Candidate version. If no grave bugs occur, it will be released as the final version in a few days. This release contains many bug fixes and several improvements for the user interface, the most important changes are listed below (and also contained in the CHANGELOG.md.&#xA;For downloading the code, head over to https://github.com/restic/restic/releases/tag/v0.6.0-rc.1 As always, thanks for reporting any issues you encounter!</description>
     </item>
     <item>
       <title>restic 0.5.0 released</title>
       <link>https://restic.net/blog/2017-03-11/restic-0.5.0-released/</link>
       <pubDate>Sat, 11 Mar 2017 00:00:00 +0000</pubDate>
       <guid>https://restic.net/blog/2017-03-11/restic-0.5.0-released/</guid>
-      <description>We&amp;rsquo;ve just released restic 0.5.0.
-This release contains (among many bug fixes) several improvements to the user interface:
-more progress bars consistent filtering for tags, hostname, or path a new command tag which allows modifying tags of existing snapshots Since we&amp;rsquo;ve internally started using the new context package, Go 1.7 is now required for compiling restic. Running build.go will check this for you. The released binaries have been compiled with Go 1.</description>
+      <description>We&amp;rsquo;ve just released restic 0.5.0.&#xA;This release contains (among many bug fixes) several improvements to the user interface:&#xA;more progress bars consistent filtering for tags, hostname, or path a new command tag which allows modifying tags of existing snapshots Since we&amp;rsquo;ve internally started using the new context package, Go 1.7 is now required for compiling restic. Running build.go will check this for you. The released binaries have been compiled with Go 1.</description>
     </item>
     <item>
       <title>restic 0.4.0 released</title>
       <link>https://restic.net/blog/2017-02-02/restic-0.4.0-released/</link>
       <pubDate>Thu, 02 Feb 2017 00:00:00 +0000</pubDate>
       <guid>https://restic.net/blog/2017-02-02/restic-0.4.0-released/</guid>
-      <description>We&amp;rsquo;ve just released restic 0.4.0. This release will use much less memory during certain operations (notably prune, but also during backup). There have also been some major internal changes which will hopefully contribute to an even larger improvement in memory usage.
-As always, thanks for reporting any issues you encounter!</description>
+      <description>We&amp;rsquo;ve just released restic 0.4.0. This release will use much less memory during certain operations (notably prune, but also during backup). There have also been some major internal changes which will hopefully contribute to an even larger improvement in memory usage.&#xA;As always, thanks for reporting any issues you encounter!</description>
     </item>
     <item>
       <title>The Go Devroom at FOSDEM 2017</title>
@@ -434,102 +363,84 @@ As always, thanks for reporting any issues you encounter!</description>
       <link>https://restic.net/blog/2017-01-08/restic-0.3.3-released/</link>
       <pubDate>Sun, 08 Jan 2017 00:00:00 +0000</pubDate>
       <guid>https://restic.net/blog/2017-01-08/restic-0.3.3-released/</guid>
-      <description>We&amp;rsquo;ve released another minor version: restic 0.3.3. As always, thanks for reporting any issues you encounter!
-Recently, several people worked together to create and upload an official Debian package for restic. A few days ago on 2 January 2017, that package entered the testing distribution, so restic will be part of the next Debian stable release!</description>
+      <description>We&amp;rsquo;ve released another minor version: restic 0.3.3. As always, thanks for reporting any issues you encounter!&#xA;Recently, several people worked together to create and upload an official Debian package for restic. A few days ago on 2 January 2017, that package entered the testing distribution, so restic will be part of the next Debian stable release!</description>
     </item>
     <item>
       <title>restic 0.3.2 released</title>
       <link>https://restic.net/blog/2016-12-18/restic-0.3.2-released/</link>
       <pubDate>Sun, 18 Dec 2016 00:00:00 +0000</pubDate>
       <guid>https://restic.net/blog/2016-12-18/restic-0.3.2-released/</guid>
-      <description>A few days ago we&amp;rsquo;ve released restic 0.3.1, unfortunately that introduced a bug which let&amp;rsquo;s restic panic when there is an error during backup. The details are described in GitHub issues #699 and #700.
-So, here it is: restic version 0.3.2.
-As always, thanks for reporting any issues you encounter!</description>
+      <description>A few days ago we&amp;rsquo;ve released restic 0.3.1, unfortunately that introduced a bug which let&amp;rsquo;s restic panic when there is an error during backup. The details are described in GitHub issues #699 and #700.&#xA;So, here it is: restic version 0.3.2.&#xA;As always, thanks for reporting any issues you encounter!</description>
     </item>
     <item>
       <title>restic 0.3.1 released</title>
       <link>https://restic.net/blog/2016-12-13/restic-0.3.1-released/</link>
       <pubDate>Tue, 13 Dec 2016 00:00:00 +0000</pubDate>
       <guid>https://restic.net/blog/2016-12-13/restic-0.3.1-released/</guid>
-      <description>We&amp;rsquo;re proud to announce the release of restic version 0.3.1. This is mainly a small bugfix release, no major new features have been added.
-The detailed change log can be found in the release notes or on GitHub.
-As always, thanks for reporting any issues you encounter!</description>
+      <description>We&amp;rsquo;re proud to announce the release of restic version 0.3.1. This is mainly a small bugfix release, no major new features have been added.&#xA;The detailed change log can be found in the release notes or on GitHub.&#xA;As always, thanks for reporting any issues you encounter!</description>
     </item>
     <item>
       <title>restic 0.3.0 released</title>
       <link>https://restic.net/blog/2016-10-01/restic-0.3.0-released/</link>
       <pubDate>Sat, 01 Oct 2016 00:00:00 +0000</pubDate>
       <guid>https://restic.net/blog/2016-10-01/restic-0.3.0-released/</guid>
-      <description>After two months development we&amp;rsquo;re proud to release restic version 0.3.0.
-The most notable change is the addition of the prune and forget commands (we&amp;rsquo;ve covered them in an earlier blog post) which allow removing backups from the repository according to configurable criteria. Since this was one of the most requested features, now that it is implemented there&amp;rsquo;s really no excuse for not making backups any more!
-The detailed change log can be found in the release notes or on GitHub.</description>
+      <description>After two months development we&amp;rsquo;re proud to release restic version 0.3.0.&#xA;The most notable change is the addition of the prune and forget commands (we&amp;rsquo;ve covered them in an earlier blog post) which allow removing backups from the repository according to configurable criteria. Since this was one of the most requested features, now that it is implemented there&amp;rsquo;s really no excuse for not making backups any more!&#xA;The detailed change log can be found in the release notes or on GitHub.</description>
     </item>
     <item>
       <title>Removing Snapshots</title>
       <link>https://restic.net/blog/2016-08-22/removing-snapshots/</link>
       <pubDate>Mon, 22 Aug 2016 00:00:00 +0000</pubDate>
       <guid>https://restic.net/blog/2016-08-22/removing-snapshots/</guid>
-      <description>The feature that was most often requested feature for restic is the ability to remove snapshots from the repository. Sometimes, restic was even (rightfully) criticised for not having such a function.
-After about three months of work, PR #518 was merged into the master branch a few days ago. This pull request brings two new commands to restic: forget and prune, which allows you to not only remove a single snapshot manually, but rather specify a policy according to which restic should automatically remove snapshots (so you don&amp;rsquo;t have to bother with them).</description>
+      <description>The feature that was most often requested feature for restic is the ability to remove snapshots from the repository. Sometimes, restic was even (rightfully) criticised for not having such a function.&#xA;After about three months of work, PR #518 was merged into the master branch a few days ago. This pull request brings two new commands to restic: forget and prune, which allows you to not only remove a single snapshot manually, but rather specify a policy according to which restic should automatically remove snapshots (so you don&amp;rsquo;t have to bother with them).</description>
     </item>
     <item>
       <title>restic 0.2.0 released</title>
       <link>https://restic.net/blog/2016-08-05/restic-0.2.0-released/</link>
       <pubDate>Fri, 05 Aug 2016 00:00:00 +0000</pubDate>
       <guid>https://restic.net/blog/2016-08-05/restic-0.2.0-released/</guid>
-      <description>A few days ago we&amp;rsquo;ve released restic 0.2.0, the detailed change log and released files can be found over at GitHub: https://github.com/restic/restic/releases/tag/v0.2.0.
-This release includes around 550 commits since version 0.1.0 (August 2015).</description>
+      <description>A few days ago we&amp;rsquo;ve released restic 0.2.0, the detailed change log and released files can be found over at GitHub: https://github.com/restic/restic/releases/tag/v0.2.0.&#xA;This release includes around 550 commits since version 0.1.0 (August 2015).</description>
     </item>
     <item>
       <title>Documentation and Manual</title>
       <link>https://restic.net/blog/2016-02-24/Documentation/</link>
       <pubDate>Wed, 24 Feb 2016 00:00:00 +0000</pubDate>
       <guid>https://restic.net/blog/2016-02-24/Documentation/</guid>
-      <description>Documentation in software projects is one of the things most developers hate. It is no secret that the docs always seem to be out of date.
-In order to improve this situation for restic, since a few days ago the manual and documentation is part of the main restic repository. Having the documentation in the main repository means that all users have instant access to the exact version of the documentation they&amp;rsquo;ll need and developers can document new features in the same Pull Request they&amp;rsquo;re submitting the code.</description>
+      <description>Documentation in software projects is one of the things most developers hate. It is no secret that the docs always seem to be out of date.&#xA;In order to improve this situation for restic, since a few days ago the manual and documentation is part of the main restic repository. Having the documentation in the main repository means that all users have instant access to the exact version of the documentation they&amp;rsquo;ll need and developers can document new features in the same Pull Request they&amp;rsquo;re submitting the code.</description>
     </item>
     <item>
       <title>OpenChaos at CCC Cologne: restic - Backups mal richtig</title>
       <link>https://restic.net/blog/2016-02-04/CCC-Cologne-OpenChaos/</link>
       <pubDate>Thu, 04 Feb 2016 00:00:00 +0000</pubDate>
       <guid>https://restic.net/blog/2016-02-04/CCC-Cologne-OpenChaos/</guid>
-      <description>On Friday, 30 January fd0 gave a talk at the Chaos Computer Club Cologne (C4) e.V. in Cologne, Germany in their monthly series of public lectures called OpenChaos. Unfortunately for our international readers the talk was given in German.
-The recording is embedded below. If you&amp;rsquo;ve watched the talk and have a question or other feedback, please contact fd0, he&amp;rsquo;d love to hear your feedback!</description>
+      <description>On Friday, 30 January fd0 gave a talk at the Chaos Computer Club Cologne (C4) e.V. in Cologne, Germany in their monthly series of public lectures called OpenChaos. Unfortunately for our international readers the talk was given in German.&#xA;The recording is embedded below. If you&amp;rsquo;ve watched the talk and have a question or other feedback, please contact fd0, he&amp;rsquo;d love to hear your feedback!</description>
     </item>
     <item>
       <title>Verifying Code Archive Integrity</title>
       <link>https://restic.net/blog/2015-09-16/verifying-code-archive-integrity/</link>
       <pubDate>Wed, 16 Sep 2015 00:00:00 +0000</pubDate>
       <guid>https://restic.net/blog/2015-09-16/verifying-code-archive-integrity/</guid>
-      <description>The restic project and all the source code, even this website is hosted by GitHub, and they provide an awesome service! This post describes how we sign releases of restic by using GnuPG so you can independently verify the integrity of the source code. In addition it is show how the automatically generated tar.gz files can be recreated with from the git repository.
-Signing Git Tags In a git repository, &amp;ldquo;tags&amp;rdquo; can be created which basically are just named pointers to a commit, optionally annotated with other data.</description>
+      <description>The restic project and all the source code, even this website is hosted by GitHub, and they provide an awesome service! This post describes how we sign releases of restic by using GnuPG so you can independently verify the integrity of the source code. In addition it is show how the automatically generated tar.gz files can be recreated with from the git repository.&#xA;Signing Git Tags In a git repository, &amp;ldquo;tags&amp;rdquo; can be created which basically are just named pointers to a commit, optionally annotated with other data.</description>
     </item>
     <item>
       <title>Foundation - Introducing Content Defined Chunking (CDC)</title>
       <link>https://restic.net/blog/2015-09-12/restic-foundation1-cdc/</link>
       <pubDate>Sat, 12 Sep 2015 00:00:00 +0000</pubDate>
       <guid>https://restic.net/blog/2015-09-12/restic-foundation1-cdc/</guid>
-      <description>This post will explain Content Defined Chunking (CDC) and how it is used by restic.
-Backup programs need to deal with large volumes of changing data. Saving the whole copy of each file again to the backup location when a subsequent (usually called &amp;ldquo;incremental&amp;rdquo;) backup is created is not efficient. Over time, different strategies have emerged to handle data in such a case.
-In a backup program, data de-duplication can be applied in two locations: Removing duplicate data from the same or different files within the same backup process (inter-file de-duplication), e.</description>
+      <description>This post will explain Content Defined Chunking (CDC) and how it is used by restic.&#xA;Backup programs need to deal with large volumes of changing data. Saving the whole copy of each file again to the backup location when a subsequent (usually called &amp;ldquo;incremental&amp;rdquo;) backup is created is not efficient. Over time, different strategies have emerged to handle data in such a case.&#xA;In a backup program, data de-duplication can be applied in two locations: Removing duplicate data from the same or different files within the same backup process (inter-file de-duplication), e.</description>
     </item>
     <item>
       <title>FrOSCon 2015 Lecture: A Solution to the Backup Inconvenience</title>
       <link>https://restic.net/blog/2015-09-12/FROSCON-2015-talk-about-restic/</link>
       <pubDate>Sat, 12 Sep 2015 00:00:00 +0000</pubDate>
       <guid>https://restic.net/blog/2015-09-12/FROSCON-2015-talk-about-restic/</guid>
-      <description>For the tenth time, FrOSCon took place at the University of Applied Sciences Bonn-Rhein-Sieg in Sankt Augustin near Bonn/Cologne on 22nd and 23rd of August. We took the chance and submitted a talk about restic titled &amp;ldquo;A Solution to the Backup Inconvenience&amp;rdquo;, which was accepted.
-You can watch the recording and view the slides. If you do so, please leave feedback1
-The recording is embedded below:
-[1] The feedback link is non-functional (2020-10-06)</description>
+      <description>For the tenth time, FrOSCon took place at the University of Applied Sciences Bonn-Rhein-Sieg in Sankt Augustin near Bonn/Cologne on 22nd and 23rd of August. We took the chance and submitted a talk about restic titled &amp;ldquo;A Solution to the Backup Inconvenience&amp;rdquo;, which was accepted.&#xA;You can watch the recording and view the slides. If you do so, please leave feedback1&#xA;The recording is embedded below:&#xA;[1] The feedback link is non-functional (2020-10-06)</description>
     </item>
     <item>
       <title>Introduction to the restic Blog - Welcome!</title>
       <link>https://restic.net/blog/2015-09-12/intro/</link>
       <pubDate>Sat, 12 Sep 2015 00:00:00 +0000</pubDate>
       <guid>https://restic.net/blog/2015-09-12/intro/</guid>
-      <description>If you&amp;rsquo;re reading this, you&amp;rsquo;ve found your way to the restic development blog, awesome! Let me welcome you on behalf of the whole development team.
-In this blog we&amp;rsquo;ll publish articles that explain the foundation techniques that restic is built upon and will give some insights into what&amp;rsquo;s happening on the development side of restic. Once restic is widely in use, we&amp;rsquo;ll probably shift the focus a bit towards the user perspective of backups and present tips and tricks for using restic more efficiently.</description>
+      <description>If you&amp;rsquo;re reading this, you&amp;rsquo;ve found your way to the restic development blog, awesome! Let me welcome you on behalf of the whole development team.&#xA;In this blog we&amp;rsquo;ll publish articles that explain the foundation techniques that restic is built upon and will give some insights into what&amp;rsquo;s happening on the development side of restic. Once restic is widely in use, we&amp;rsquo;ll probably shift the focus a bit towards the user perspective of backups and present tips and tricks for using restic more efficiently.</description>
     </item>
   </channel>
 </rss>

--- a/public/tags/index.html
+++ b/public/tags/index.html
@@ -271,8 +271,18 @@
         <a href="/tags/index.xml">RSS Feed</a>
     </div>
 
-    <a href="https://github.com/restic/restic" class="desktop">
-	<img style="position: fixed; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/38ef81f8aca64bb9a64448d0d70f1308ef5341ab/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png">
+    
+<a href="https://github.com/restic/restic" class="github-corner desktop" aria-label="View restic on GitHub">
+	<svg width="80" height="80" viewBox="0 0 250 250" style="fill:#202020; color:#fff; position: absolute; top: 0; border: 0; right: 0;" aria-hidden="true">
+		<title>View restic on GitHub</title>
+		<path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
+		<path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path>
+		<path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path>
+	</svg>
 </a>
+<style>
+	.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}
+</style>
+
   </body>
 </html>


### PR DESCRIPTION
- Fix broken link to about Read the Docs
- Replace broken GitHub banner image with SVG
- Replace build.sh with updated Hugo config
- Upgrade Hugo to (extended) version 0.121.2
- Upgrade Muffet to version 2.9.3
- Fix broken build status banner