### PR TITLE
Add blog post for restic 0.16.5

### DIFF
--- a/content/blog/restic-0.16.5-released.md
+++ b/content/blog/restic-0.16.5-released.md
@@ -1,0 +1,12 @@
+---
+title: "Restic 0.16.5 Released"
+date: 2024-07-01T21:00:00+02:00
+---
+
+We are happy to announce the release of [restic 0.16.5](https://github.com/restic/restic/releases/v0.16.5)!
+
+This release updates a few potentially vulnerable dependencies.
+
+To download the new release and to see a more detailed list of important changes, please head over to [GitHub](https://github.com/restic/restic/releases/v0.16.5). If you already have restic (0.9.4 or later), you can use the `self-update` command to automatically download and verify the new release.
+
+As always, thanks for [reporting any issues](https://github.com/restic/restic/issues/new/choose) you encounter! To get help or provide feedback, please write a post in [the forum](https://forum.restic.net).

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -26,8 +26,8 @@
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=PT+Sans:400,400italic,700|Abril+Fatface">
 
   <!-- Icons -->
-  <link rel="apple-touch-icon-precomposed" sizes="144x144" href="{{ .Site.BaseURL }}/apple-touch-icon-144-precomposed.png">
-  <link rel="shortcut icon" href="{{ .Site.BaseURL }}/favicon.ico">
+  <link rel="apple-touch-icon-precomposed" sizes="144x144" href="{{ .Site.BaseURL }}apple-touch-icon-144-precomposed.png">
+  <link rel="shortcut icon" href="{{ .Site.BaseURL }}favicon.ico">
 
   <!-- RSS -->
   {{ with .OutputFormats.Get "rss" -}}

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -2,13 +2,13 @@
   <div class="container sidebar-sticky">
     <div class="sidebar-about">
       <h1>
-        <a href="{{ .Site.BaseURL }}/">{{ .Site.Title }}</a>
+        <a href="{{ .Site.BaseURL }}">{{ .Site.Title }}</a>
       </h1>
       <p class="lead">{{ .Site.Params.tagline }}</p>
     </div>
 
     <nav class="sidebar-nav">
-      <a class="sidebar-nav-item{{ if eq .Page.Permalink .Site.BaseURL }} active{{ end }}{{ if eq .Page.RelPermalink "/index.html" }} active{{ end }}" href="{{ .Site.BaseURL }}/">Home</a>
+      <a class="sidebar-nav-item{{ if eq .Page.Permalink .Site.BaseURL }} active{{ end }}{{ if eq .Page.RelPermalink "/index.html" }} active{{ end }}" href="{{ .Site.BaseURL }}">Home</a>
 
       {{- $currentPage := . }}
       {{- range .Site.Pages }}

--- a/public/blog/2015-09-12/FROSCON-2015-talk-about-restic/index.html
+++ b/public/blog/2015-09-12/FROSCON-2015-talk-about-restic/index.html
@@ -108,13 +108,13 @@ If you do so, please <del><a href="">leave feedback</a></del><sup>1</sup></p>
           
           <ul>
 <li>
+<p>01 Jul 2024 » <a href="/blog/2024-07-01/restic-0.16.5-released/">Restic 0.16.5 Released</a></p>
+</li>
+<li>
 <p>04 Feb 2024 » <a href="/blog/2024-02-04/restic-0.16.4-released/">Restic 0.16.4 Released</a></p>
 </li>
 <li>
 <p>14 Jan 2024 » <a href="/blog/2024-01-14/restic-0.16.3-released/">Restic 0.16.3 Released</a></p>
-</li>
-<li>
-<p>29 Oct 2023 » <a href="/blog/2023-10-29/restic-0.16.2-released/">Restic 0.16.2 Released</a></p>
 </li>
 </ul>
 

--- a/public/blog/2015-09-12/intro/index.html
+++ b/public/blog/2015-09-12/intro/index.html
@@ -105,13 +105,13 @@ tricks for using restic more efficiently.</p>
           
           <ul>
 <li>
+<p>01 Jul 2024 » <a href="/blog/2024-07-01/restic-0.16.5-released/">Restic 0.16.5 Released</a></p>
+</li>
+<li>
 <p>04 Feb 2024 » <a href="/blog/2024-02-04/restic-0.16.4-released/">Restic 0.16.4 Released</a></p>
 </li>
 <li>
 <p>14 Jan 2024 » <a href="/blog/2024-01-14/restic-0.16.3-released/">Restic 0.16.3 Released</a></p>
-</li>
-<li>
-<p>29 Oct 2023 » <a href="/blog/2023-10-29/restic-0.16.2-released/">Restic 0.16.2 Released</a></p>
 </li>
 </ul>
 

--- a/public/blog/2015-09-12/restic-foundation1-cdc/index.html
+++ b/public/blog/2015-09-12/restic-foundation1-cdc/index.html
@@ -334,13 +334,13 @@ This gives us not only <em>inter-file</em> de-duplication, but also the more rel
           
           <ul>
 <li>
+<p>01 Jul 2024 » <a href="/blog/2024-07-01/restic-0.16.5-released/">Restic 0.16.5 Released</a></p>
+</li>
+<li>
 <p>04 Feb 2024 » <a href="/blog/2024-02-04/restic-0.16.4-released/">Restic 0.16.4 Released</a></p>
 </li>
 <li>
 <p>14 Jan 2024 » <a href="/blog/2024-01-14/restic-0.16.3-released/">Restic 0.16.3 Released</a></p>
-</li>
-<li>
-<p>29 Oct 2023 » <a href="/blog/2023-10-29/restic-0.16.2-released/">Restic 0.16.2 Released</a></p>
 </li>
 </ul>
 

--- a/public/blog/2015-09-16/verifying-code-archive-integrity/index.html
+++ b/public/blog/2015-09-16/verifying-code-archive-integrity/index.html
@@ -165,13 +165,13 @@ addition a GPG signature is provided for the <code>tar.gz</code> files for each 
           
           <ul>
 <li>
+<p>01 Jul 2024 » <a href="/blog/2024-07-01/restic-0.16.5-released/">Restic 0.16.5 Released</a></p>
+</li>
+<li>
 <p>04 Feb 2024 » <a href="/blog/2024-02-04/restic-0.16.4-released/">Restic 0.16.4 Released</a></p>
 </li>
 <li>
 <p>14 Jan 2024 » <a href="/blog/2024-01-14/restic-0.16.3-released/">Restic 0.16.3 Released</a></p>
-</li>
-<li>
-<p>29 Oct 2023 » <a href="/blog/2023-10-29/restic-0.16.2-released/">Restic 0.16.2 Released</a></p>
 </li>
 </ul>
 

--- a/public/blog/2016-02-04/CCC-Cologne-OpenChaos/index.html
+++ b/public/blog/2016-02-04/CCC-Cologne-OpenChaos/index.html
@@ -105,13 +105,13 @@ below. If you&rsquo;ve watched the talk and have a question or other feedback, p
           
           <ul>
 <li>
+<p>01 Jul 2024 » <a href="/blog/2024-07-01/restic-0.16.5-released/">Restic 0.16.5 Released</a></p>
+</li>
+<li>
 <p>04 Feb 2024 » <a href="/blog/2024-02-04/restic-0.16.4-released/">Restic 0.16.4 Released</a></p>
 </li>
 <li>
 <p>14 Jan 2024 » <a href="/blog/2024-01-14/restic-0.16.3-released/">Restic 0.16.3 Released</a></p>
-</li>
-<li>
-<p>29 Oct 2023 » <a href="/blog/2023-10-29/restic-0.16.2-released/">Restic 0.16.2 Released</a></p>
 </li>
 </ul>
 

--- a/public/blog/2016-02-24/Documentation/index.html
+++ b/public/blog/2016-02-24/Documentation/index.html
@@ -126,13 +126,13 @@ return the docs for the latest master branch.</p>
           
           <ul>
 <li>
+<p>01 Jul 2024 » <a href="/blog/2024-07-01/restic-0.16.5-released/">Restic 0.16.5 Released</a></p>
+</li>
+<li>
 <p>04 Feb 2024 » <a href="/blog/2024-02-04/restic-0.16.4-released/">Restic 0.16.4 Released</a></p>
 </li>
 <li>
 <p>14 Jan 2024 » <a href="/blog/2024-01-14/restic-0.16.3-released/">Restic 0.16.3 Released</a></p>
-</li>
-<li>
-<p>29 Oct 2023 » <a href="/blog/2023-10-29/restic-0.16.2-released/">Restic 0.16.2 Released</a></p>
 </li>
 </ul>
 

--- a/public/blog/2016-08-05/restic-0.2.0-released/index.html
+++ b/public/blog/2016-08-05/restic-0.2.0-released/index.html
@@ -101,13 +101,13 @@ the detailed change log and released files can be found over at GitHub:
           
           <ul>
 <li>
+<p>01 Jul 2024 » <a href="/blog/2024-07-01/restic-0.16.5-released/">Restic 0.16.5 Released</a></p>
+</li>
+<li>
 <p>04 Feb 2024 » <a href="/blog/2024-02-04/restic-0.16.4-released/">Restic 0.16.4 Released</a></p>
 </li>
 <li>
 <p>14 Jan 2024 » <a href="/blog/2024-01-14/restic-0.16.3-released/">Restic 0.16.3 Released</a></p>
-</li>
-<li>
-<p>29 Oct 2023 » <a href="/blog/2023-10-29/restic-0.16.2-released/">Restic 0.16.2 Released</a></p>
 </li>
 </ul>
 

--- a/public/blog/2016-08-22/removing-snapshots/index.html
+++ b/public/blog/2016-08-22/removing-snapshots/index.html
@@ -349,13 +349,13 @@ you notice any odd behavior or find bugs.</p>
           
           <ul>
 <li>
+<p>01 Jul 2024 » <a href="/blog/2024-07-01/restic-0.16.5-released/">Restic 0.16.5 Released</a></p>
+</li>
+<li>
 <p>04 Feb 2024 » <a href="/blog/2024-02-04/restic-0.16.4-released/">Restic 0.16.4 Released</a></p>
 </li>
 <li>
 <p>14 Jan 2024 » <a href="/blog/2024-01-14/restic-0.16.3-released/">Restic 0.16.3 Released</a></p>
-</li>
-<li>
-<p>29 Oct 2023 » <a href="/blog/2023-10-29/restic-0.16.2-released/">Restic 0.16.2 Released</a></p>
 </li>
 </ul>
 

--- a/public/blog/2016-10-01/restic-0.3.0-released/index.html
+++ b/public/blog/2016-10-01/restic-0.3.0-released/index.html
@@ -101,13 +101,13 @@
           
           <ul>
 <li>
+<p>01 Jul 2024 » <a href="/blog/2024-07-01/restic-0.16.5-released/">Restic 0.16.5 Released</a></p>
+</li>
+<li>
 <p>04 Feb 2024 » <a href="/blog/2024-02-04/restic-0.16.4-released/">Restic 0.16.4 Released</a></p>
 </li>
 <li>
 <p>14 Jan 2024 » <a href="/blog/2024-01-14/restic-0.16.3-released/">Restic 0.16.3 Released</a></p>
-</li>
-<li>
-<p>29 Oct 2023 » <a href="/blog/2023-10-29/restic-0.16.2-released/">Restic 0.16.2 Released</a></p>
 </li>
 </ul>
 

--- a/public/blog/2016-12-13/restic-0.3.1-released/index.html
+++ b/public/blog/2016-12-13/restic-0.3.1-released/index.html
@@ -100,13 +100,13 @@
           
           <ul>
 <li>
+<p>01 Jul 2024 » <a href="/blog/2024-07-01/restic-0.16.5-released/">Restic 0.16.5 Released</a></p>
+</li>
+<li>
 <p>04 Feb 2024 » <a href="/blog/2024-02-04/restic-0.16.4-released/">Restic 0.16.4 Released</a></p>
 </li>
 <li>
 <p>14 Jan 2024 » <a href="/blog/2024-01-14/restic-0.16.3-released/">Restic 0.16.3 Released</a></p>
-</li>
-<li>
-<p>29 Oct 2023 » <a href="/blog/2023-10-29/restic-0.16.2-released/">Restic 0.16.2 Released</a></p>
 </li>
 </ul>
 

--- a/public/blog/2016-12-18/restic-0.3.2-released/index.html
+++ b/public/blog/2016-12-18/restic-0.3.2-released/index.html
@@ -100,13 +100,13 @@
           
           <ul>
 <li>
+<p>01 Jul 2024 » <a href="/blog/2024-07-01/restic-0.16.5-released/">Restic 0.16.5 Released</a></p>
+</li>
+<li>
 <p>04 Feb 2024 » <a href="/blog/2024-02-04/restic-0.16.4-released/">Restic 0.16.4 Released</a></p>
 </li>
 <li>
 <p>14 Jan 2024 » <a href="/blog/2024-01-14/restic-0.16.3-released/">Restic 0.16.3 Released</a></p>
-</li>
-<li>
-<p>29 Oct 2023 » <a href="/blog/2023-10-29/restic-0.16.2-released/">Restic 0.16.2 Released</a></p>
 </li>
 </ul>
 

--- a/public/blog/2017-01-08/restic-0.3.3-released/index.html
+++ b/public/blog/2017-01-08/restic-0.3.3-released/index.html
@@ -101,13 +101,13 @@ A few days ago on 2 January 2017, that package entered the <code>testing</code> 
           
           <ul>
 <li>
+<p>01 Jul 2024 » <a href="/blog/2024-07-01/restic-0.16.5-released/">Restic 0.16.5 Released</a></p>
+</li>
+<li>
 <p>04 Feb 2024 » <a href="/blog/2024-02-04/restic-0.16.4-released/">Restic 0.16.4 Released</a></p>
 </li>
 <li>
 <p>14 Jan 2024 » <a href="/blog/2024-01-14/restic-0.16.3-released/">Restic 0.16.3 Released</a></p>
-</li>
-<li>
-<p>29 Oct 2023 » <a href="/blog/2023-10-29/restic-0.16.2-released/">Restic 0.16.2 Released</a></p>
 </li>
 </ul>
 

--- a/public/blog/2017-02-02/FOSDEM-2017-Brussels/index.html
+++ b/public/blog/2017-02-02/FOSDEM-2017-Brussels/index.html
@@ -101,13 +101,13 @@ features a room on Sunday (5 February 2017) dedicated to Go development: <a href
           
           <ul>
 <li>
+<p>01 Jul 2024 » <a href="/blog/2024-07-01/restic-0.16.5-released/">Restic 0.16.5 Released</a></p>
+</li>
+<li>
 <p>04 Feb 2024 » <a href="/blog/2024-02-04/restic-0.16.4-released/">Restic 0.16.4 Released</a></p>
 </li>
 <li>
 <p>14 Jan 2024 » <a href="/blog/2024-01-14/restic-0.16.3-released/">Restic 0.16.3 Released</a></p>
-</li>
-<li>
-<p>29 Oct 2023 » <a href="/blog/2023-10-29/restic-0.16.2-released/">Restic 0.16.2 Released</a></p>
 </li>
 </ul>
 

--- a/public/blog/2017-02-02/restic-0.4.0-released/index.html
+++ b/public/blog/2017-02-02/restic-0.4.0-released/index.html
@@ -99,13 +99,13 @@
           
           <ul>
 <li>
+<p>01 Jul 2024 » <a href="/blog/2024-07-01/restic-0.16.5-released/">Restic 0.16.5 Released</a></p>
+</li>
+<li>
 <p>04 Feb 2024 » <a href="/blog/2024-02-04/restic-0.16.4-released/">Restic 0.16.4 Released</a></p>
 </li>
 <li>
 <p>14 Jan 2024 » <a href="/blog/2024-01-14/restic-0.16.3-released/">Restic 0.16.3 Released</a></p>
-</li>
-<li>
-<p>29 Oct 2023 » <a href="/blog/2023-10-29/restic-0.16.2-released/">Restic 0.16.2 Released</a></p>
 </li>
 </ul>
 

--- a/public/blog/2017-03-11/restic-0.5.0-released/index.html
+++ b/public/blog/2017-03-11/restic-0.5.0-released/index.html
@@ -108,13 +108,13 @@ released binaries have been compiled with Go 1.8.</p>
           
           <ul>
 <li>
+<p>01 Jul 2024 » <a href="/blog/2024-07-01/restic-0.16.5-released/">Restic 0.16.5 Released</a></p>
+</li>
+<li>
 <p>04 Feb 2024 » <a href="/blog/2024-02-04/restic-0.16.4-released/">Restic 0.16.4 Released</a></p>
 </li>
 <li>
 <p>14 Jan 2024 » <a href="/blog/2024-01-14/restic-0.16.3-released/">Restic 0.16.3 Released</a></p>
-</li>
-<li>
-<p>29 Oct 2023 » <a href="/blog/2023-10-29/restic-0.16.2-released/">Restic 0.16.2 Released</a></p>
 </li>
 </ul>
 

--- a/public/blog/2017-05-25/restic-0.6.0-rc.1-released/index.html
+++ b/public/blog/2017-05-25/restic-0.6.0-rc.1-released/index.html
@@ -108,13 +108,13 @@ As always, thanks for <a href="https://github.com/restic/restic/issues/new">repo
           
           <ul>
 <li>
+<p>01 Jul 2024 » <a href="/blog/2024-07-01/restic-0.16.5-released/">Restic 0.16.5 Released</a></p>
+</li>
+<li>
 <p>04 Feb 2024 » <a href="/blog/2024-02-04/restic-0.16.4-released/">Restic 0.16.4 Released</a></p>
 </li>
 <li>
 <p>14 Jan 2024 » <a href="/blog/2024-01-14/restic-0.16.3-released/">Restic 0.16.3 Released</a></p>
-</li>
-<li>
-<p>29 Oct 2023 » <a href="/blog/2023-10-29/restic-0.16.2-released/">Restic 0.16.2 Released</a></p>
 </li>
 </ul>
 

--- a/public/blog/2017-05-29/restic-0.6.0-released/index.html
+++ b/public/blog/2017-05-29/restic-0.6.0-released/index.html
@@ -108,13 +108,13 @@ As always, thanks for <a href="https://github.com/restic/restic/issues/new">repo
           
           <ul>
 <li>
+<p>01 Jul 2024 » <a href="/blog/2024-07-01/restic-0.16.5-released/">Restic 0.16.5 Released</a></p>
+</li>
+<li>
 <p>04 Feb 2024 » <a href="/blog/2024-02-04/restic-0.16.4-released/">Restic 0.16.4 Released</a></p>
 </li>
 <li>
 <p>14 Jan 2024 » <a href="/blog/2024-01-14/restic-0.16.3-released/">Restic 0.16.3 Released</a></p>
-</li>
-<li>
-<p>29 Oct 2023 » <a href="/blog/2023-10-29/restic-0.16.2-released/">Restic 0.16.2 Released</a></p>
 </li>
 </ul>
 

--- a/public/blog/2017-05-29/restic-0.6.1-released/index.html
+++ b/public/blog/2017-05-29/restic-0.6.1-released/index.html
@@ -128,13 +128,13 @@ the binary. This is the first step in enabling reproducible builds.
           
           <ul>
 <li>
+<p>01 Jul 2024 » <a href="/blog/2024-07-01/restic-0.16.5-released/">Restic 0.16.5 Released</a></p>
+</li>
+<li>
 <p>04 Feb 2024 » <a href="/blog/2024-02-04/restic-0.16.4-released/">Restic 0.16.4 Released</a></p>
 </li>
 <li>
 <p>14 Jan 2024 » <a href="/blog/2024-01-14/restic-0.16.3-released/">Restic 0.16.3 Released</a></p>
-</li>
-<li>
-<p>29 Oct 2023 » <a href="/blog/2023-10-29/restic-0.16.2-released/">Restic 0.16.2 Released</a></p>
 </li>
 </ul>
 

--- a/public/blog/2017-06-01/restic-on-gotime/index.html
+++ b/public/blog/2017-06-01/restic-on-gotime/index.html
@@ -100,13 +100,13 @@
           
           <ul>
 <li>
+<p>01 Jul 2024 » <a href="/blog/2024-07-01/restic-0.16.5-released/">Restic 0.16.5 Released</a></p>
+</li>
+<li>
 <p>04 Feb 2024 » <a href="/blog/2024-02-04/restic-0.16.4-released/">Restic 0.16.4 Released</a></p>
 </li>
 <li>
 <p>14 Jan 2024 » <a href="/blog/2024-01-14/restic-0.16.3-released/">Restic 0.16.3 Released</a></p>
-</li>
-<li>
-<p>29 Oct 2023 » <a href="/blog/2023-10-29/restic-0.16.2-released/">Restic 0.16.2 Released</a></p>
 </li>
 </ul>
 

--- a/public/blog/2017-07-01/restic-0.7.0-released/index.html
+++ b/public/blog/2017-07-01/restic-0.7.0-released/index.html
@@ -166,13 +166,13 @@ returns an error message.
           
           <ul>
 <li>
+<p>01 Jul 2024 » <a href="/blog/2024-07-01/restic-0.16.5-released/">Restic 0.16.5 Released</a></p>
+</li>
+<li>
 <p>04 Feb 2024 » <a href="/blog/2024-02-04/restic-0.16.4-released/">Restic 0.16.4 Released</a></p>
 </li>
 <li>
 <p>14 Jan 2024 » <a href="/blog/2024-01-14/restic-0.16.3-released/">Restic 0.16.3 Released</a></p>
-</li>
-<li>
-<p>29 Oct 2023 » <a href="/blog/2023-10-29/restic-0.16.2-released/">Restic 0.16.2 Released</a></p>
 </li>
 </ul>
 

--- a/public/blog/2017-07-21/FrOSCon-Bonn/index.html
+++ b/public/blog/2017-07-21/FrOSCon-Bonn/index.html
@@ -98,13 +98,13 @@
           
           <ul>
 <li>
+<p>01 Jul 2024 » <a href="/blog/2024-07-01/restic-0.16.5-released/">Restic 0.16.5 Released</a></p>
+</li>
+<li>
 <p>04 Feb 2024 » <a href="/blog/2024-02-04/restic-0.16.4-released/">Restic 0.16.4 Released</a></p>
 </li>
 <li>
 <p>14 Jan 2024 » <a href="/blog/2024-01-14/restic-0.16.3-released/">Restic 0.16.3 Released</a></p>
-</li>
-<li>
-<p>29 Oct 2023 » <a href="/blog/2023-10-29/restic-0.16.2-released/">Restic 0.16.2 Released</a></p>
 </li>
 </ul>
 

--- a/public/blog/2017-07-22/restic-0.7.1-released/index.html
+++ b/public/blog/2017-07-22/restic-0.7.1-released/index.html
@@ -129,13 +129,13 @@ As always, thanks for <a href="https://github.com/restic/restic/issues/new">repo
           
           <ul>
 <li>
+<p>01 Jul 2024 » <a href="/blog/2024-07-01/restic-0.16.5-released/">Restic 0.16.5 Released</a></p>
+</li>
+<li>
 <p>04 Feb 2024 » <a href="/blog/2024-02-04/restic-0.16.4-released/">Restic 0.16.4 Released</a></p>
 </li>
 <li>
 <p>14 Jan 2024 » <a href="/blog/2024-01-14/restic-0.16.3-released/">Restic 0.16.3 Released</a></p>
-</li>
-<li>
-<p>29 Oct 2023 » <a href="/blog/2023-10-29/restic-0.16.2-released/">Restic 0.16.2 Released</a></p>
 </li>
 </ul>
 

--- a/public/blog/2017-07-25/please-upgrade-to-0.7.1/index.html
+++ b/public/blog/2017-07-25/please-upgrade-to-0.7.1/index.html
@@ -225,13 +225,13 @@ and finally <code>check</code> to see if there&rsquo;s any error.</p>
           
           <ul>
 <li>
+<p>01 Jul 2024 » <a href="/blog/2024-07-01/restic-0.16.5-released/">Restic 0.16.5 Released</a></p>
+</li>
+<li>
 <p>04 Feb 2024 » <a href="/blog/2024-02-04/restic-0.16.4-released/">Restic 0.16.4 Released</a></p>
 </li>
 <li>
 <p>14 Jan 2024 » <a href="/blog/2024-01-14/restic-0.16.3-released/">Restic 0.16.3 Released</a></p>
-</li>
-<li>
-<p>29 Oct 2023 » <a href="/blog/2023-10-29/restic-0.16.2-released/">Restic 0.16.2 Released</a></p>
 </li>
 </ul>
 

--- a/public/blog/2017-08-11/discourse-forum/index.html
+++ b/public/blog/2017-08-11/discourse-forum/index.html
@@ -99,13 +99,13 @@
           
           <ul>
 <li>
+<p>01 Jul 2024 » <a href="/blog/2024-07-01/restic-0.16.5-released/">Restic 0.16.5 Released</a></p>
+</li>
+<li>
 <p>04 Feb 2024 » <a href="/blog/2024-02-04/restic-0.16.4-released/">Restic 0.16.4 Released</a></p>
 </li>
 <li>
 <p>14 Jan 2024 » <a href="/blog/2024-01-14/restic-0.16.3-released/">Restic 0.16.3 Released</a></p>
-</li>
-<li>
-<p>29 Oct 2023 » <a href="/blog/2023-10-29/restic-0.16.2-released/">Restic 0.16.2 Released</a></p>
 </li>
 </ul>
 

--- a/public/blog/2017-09-13/restic-0.7.2-released/index.html
+++ b/public/blog/2017-09-13/restic-0.7.2-released/index.html
@@ -190,13 +190,13 @@ As always, thanks for <a href="https://github.com/restic/restic/issues/new">repo
           
           <ul>
 <li>
+<p>01 Jul 2024 » <a href="/blog/2024-07-01/restic-0.16.5-released/">Restic 0.16.5 Released</a></p>
+</li>
+<li>
 <p>04 Feb 2024 » <a href="/blog/2024-02-04/restic-0.16.4-released/">Restic 0.16.4 Released</a></p>
 </li>
 <li>
 <p>14 Jan 2024 » <a href="/blog/2024-01-14/restic-0.16.3-released/">Restic 0.16.3 Released</a></p>
-</li>
-<li>
-<p>29 Oct 2023 » <a href="/blog/2023-10-29/restic-0.16.2-released/">Restic 0.16.2 Released</a></p>
 </li>
 </ul>
 

--- a/public/blog/2017-09-20/restic-0.7.3-released/index.html
+++ b/public/blog/2017-09-20/restic-0.7.3-released/index.html
@@ -106,13 +106,13 @@ As always, thanks for <a href="https://github.com/restic/restic/issues/new">repo
           
           <ul>
 <li>
+<p>01 Jul 2024 » <a href="/blog/2024-07-01/restic-0.16.5-released/">Restic 0.16.5 Released</a></p>
+</li>
+<li>
 <p>04 Feb 2024 » <a href="/blog/2024-02-04/restic-0.16.4-released/">Restic 0.16.4 Released</a></p>
 </li>
 <li>
 <p>14 Jan 2024 » <a href="/blog/2024-01-14/restic-0.16.3-released/">Restic 0.16.3 Released</a></p>
-</li>
-<li>
-<p>29 Oct 2023 » <a href="/blog/2023-10-29/restic-0.16.2-released/">Restic 0.16.2 Released</a></p>
 </li>
 </ul>
 

--- a/public/blog/2017-11-25/upcoming-changes-to-s3/index.html
+++ b/public/blog/2017-11-25/upcoming-changes-to-s3/index.html
@@ -115,13 +115,13 @@ s3:s3.amazonaws.com/backup-servers
           
           <ul>
 <li>
+<p>01 Jul 2024 » <a href="/blog/2024-07-01/restic-0.16.5-released/">Restic 0.16.5 Released</a></p>
+</li>
+<li>
 <p>04 Feb 2024 » <a href="/blog/2024-02-04/restic-0.16.4-released/">Restic 0.16.4 Released</a></p>
 </li>
 <li>
 <p>14 Jan 2024 » <a href="/blog/2024-01-14/restic-0.16.3-released/">Restic 0.16.3 Released</a></p>
-</li>
-<li>
-<p>29 Oct 2023 » <a href="/blog/2023-10-29/restic-0.16.2-released/">Restic 0.16.2 Released</a></p>
 </li>
 </ul>
 

--- a/public/blog/2017-11-26/restic-0.8.0-released/index.html
+++ b/public/blog/2017-11-26/restic-0.8.0-released/index.html
@@ -108,13 +108,13 @@
           
           <ul>
 <li>
+<p>01 Jul 2024 » <a href="/blog/2024-07-01/restic-0.16.5-released/">Restic 0.16.5 Released</a></p>
+</li>
+<li>
 <p>04 Feb 2024 » <a href="/blog/2024-02-04/restic-0.16.4-released/">Restic 0.16.4 Released</a></p>
 </li>
 <li>
 <p>14 Jan 2024 » <a href="/blog/2024-01-14/restic-0.16.3-released/">Restic 0.16.3 Released</a></p>
-</li>
-<li>
-<p>29 Oct 2023 » <a href="/blog/2023-10-29/restic-0.16.2-released/">Restic 0.16.2 Released</a></p>
 </li>
 </ul>
 

--- a/public/blog/2017-12-27/restic-0.8.1-released/index.html
+++ b/public/blog/2017-12-27/restic-0.8.1-released/index.html
@@ -99,13 +99,13 @@
           
           <ul>
 <li>
+<p>01 Jul 2024 » <a href="/blog/2024-07-01/restic-0.16.5-released/">Restic 0.16.5 Released</a></p>
+</li>
+<li>
 <p>04 Feb 2024 » <a href="/blog/2024-02-04/restic-0.16.4-released/">Restic 0.16.4 Released</a></p>
 </li>
 <li>
 <p>14 Jan 2024 » <a href="/blog/2024-01-14/restic-0.16.3-released/">Restic 0.16.3 Released</a></p>
-</li>
-<li>
-<p>29 Oct 2023 » <a href="/blog/2023-10-29/restic-0.16.2-released/">Restic 0.16.2 Released</a></p>
 </li>
 </ul>
 

--- a/public/blog/2018-01-01/moving-domain/index.html
+++ b/public/blog/2018-01-01/moving-domain/index.html
@@ -108,13 +108,13 @@ so you don&rsquo;t miss out on any new posts! :)</p>
           
           <ul>
 <li>
+<p>01 Jul 2024 » <a href="/blog/2024-07-01/restic-0.16.5-released/">Restic 0.16.5 Released</a></p>
+</li>
+<li>
 <p>04 Feb 2024 » <a href="/blog/2024-02-04/restic-0.16.4-released/">Restic 0.16.4 Released</a></p>
 </li>
 <li>
 <p>14 Jan 2024 » <a href="/blog/2024-01-14/restic-0.16.3-released/">Restic 0.16.3 Released</a></p>
-</li>
-<li>
-<p>29 Oct 2023 » <a href="/blog/2023-10-29/restic-0.16.2-released/">Restic 0.16.2 Released</a></p>
 </li>
 </ul>
 

--- a/public/blog/2018-02-17/restic-0.8.2-released/index.html
+++ b/public/blog/2018-02-17/restic-0.8.2-released/index.html
@@ -99,13 +99,13 @@
           
           <ul>
 <li>
+<p>01 Jul 2024 » <a href="/blog/2024-07-01/restic-0.16.5-released/">Restic 0.16.5 Released</a></p>
+</li>
+<li>
 <p>04 Feb 2024 » <a href="/blog/2024-02-04/restic-0.16.4-released/">Restic 0.16.4 Released</a></p>
 </li>
 <li>
 <p>14 Jan 2024 » <a href="/blog/2024-01-14/restic-0.16.3-released/">Restic 0.16.3 Released</a></p>
-</li>
-<li>
-<p>29 Oct 2023 » <a href="/blog/2023-10-29/restic-0.16.2-released/">Restic 0.16.2 Released</a></p>
 </li>
 </ul>
 

--- a/public/blog/2018-02-26/restic-0.8.3-released/index.html
+++ b/public/blog/2018-02-26/restic-0.8.3-released/index.html
@@ -99,13 +99,13 @@
           
           <ul>
 <li>
+<p>01 Jul 2024 » <a href="/blog/2024-07-01/restic-0.16.5-released/">Restic 0.16.5 Released</a></p>
+</li>
+<li>
 <p>04 Feb 2024 » <a href="/blog/2024-02-04/restic-0.16.4-released/">Restic 0.16.4 Released</a></p>
 </li>
 <li>
 <p>14 Jan 2024 » <a href="/blog/2024-01-14/restic-0.16.3-released/">Restic 0.16.3 Released</a></p>
-</li>
-<li>
-<p>29 Oct 2023 » <a href="/blog/2023-10-29/restic-0.16.2-released/">Restic 0.16.2 Released</a></p>
 </li>
 </ul>
 

--- a/public/blog/2018-04-01/rclone-backend/index.html
+++ b/public/blog/2018-04-01/rclone-backend/index.html
@@ -126,13 +126,13 @@ created restic repository 7905a088a0 at rclone:b2prod:yggdrasil/prod-serverA
           
           <ul>
 <li>
+<p>01 Jul 2024 » <a href="/blog/2024-07-01/restic-0.16.5-released/">Restic 0.16.5 Released</a></p>
+</li>
+<li>
 <p>04 Feb 2024 » <a href="/blog/2024-02-04/restic-0.16.4-released/">Restic 0.16.4 Released</a></p>
 </li>
 <li>
 <p>14 Jan 2024 » <a href="/blog/2024-01-14/restic-0.16.3-released/">Restic 0.16.3 Released</a></p>
-</li>
-<li>
-<p>29 Oct 2023 » <a href="/blog/2023-10-29/restic-0.16.2-released/">Restic 0.16.2 Released</a></p>
 </li>
 </ul>
 

--- a/public/blog/2018-04-06/restic-turns-four/index.html
+++ b/public/blog/2018-04-06/restic-turns-four/index.html
@@ -104,13 +104,13 @@
           
           <ul>
 <li>
+<p>01 Jul 2024 » <a href="/blog/2024-07-01/restic-0.16.5-released/">Restic 0.16.5 Released</a></p>
+</li>
+<li>
 <p>04 Feb 2024 » <a href="/blog/2024-02-04/restic-0.16.4-released/">Restic 0.16.4 Released</a></p>
 </li>
 <li>
 <p>14 Jan 2024 » <a href="/blog/2024-01-14/restic-0.16.3-released/">Restic 0.16.3 Released</a></p>
-</li>
-<li>
-<p>29 Oct 2023 » <a href="/blog/2023-10-29/restic-0.16.2-released/">Restic 0.16.2 Released</a></p>
 </li>
 </ul>
 

--- a/public/blog/2018-05-21/restic-0.9.0-released/index.html
+++ b/public/blog/2018-05-21/restic-0.9.0-released/index.html
@@ -99,13 +99,13 @@
           
           <ul>
 <li>
+<p>01 Jul 2024 » <a href="/blog/2024-07-01/restic-0.16.5-released/">Restic 0.16.5 Released</a></p>
+</li>
+<li>
 <p>04 Feb 2024 » <a href="/blog/2024-02-04/restic-0.16.4-released/">Restic 0.16.4 Released</a></p>
 </li>
 <li>
 <p>14 Jan 2024 » <a href="/blog/2024-01-14/restic-0.16.3-released/">Restic 0.16.3 Released</a></p>
-</li>
-<li>
-<p>29 Oct 2023 » <a href="/blog/2023-10-29/restic-0.16.2-released/">Restic 0.16.2 Released</a></p>
 </li>
 </ul>
 

--- a/public/blog/2018-06-10/restic-0.9.1-released/index.html
+++ b/public/blog/2018-06-10/restic-0.9.1-released/index.html
@@ -99,13 +99,13 @@
           
           <ul>
 <li>
+<p>01 Jul 2024 » <a href="/blog/2024-07-01/restic-0.16.5-released/">Restic 0.16.5 Released</a></p>
+</li>
+<li>
 <p>04 Feb 2024 » <a href="/blog/2024-02-04/restic-0.16.4-released/">Restic 0.16.4 Released</a></p>
 </li>
 <li>
 <p>14 Jan 2024 » <a href="/blog/2024-01-14/restic-0.16.3-released/">Restic 0.16.3 Released</a></p>
-</li>
-<li>
-<p>29 Oct 2023 » <a href="/blog/2023-10-29/restic-0.16.2-released/">Restic 0.16.2 Released</a></p>
 </li>
 </ul>
 

--- a/public/blog/2018-08-06/restic-0.9.2-released/index.html
+++ b/public/blog/2018-08-06/restic-0.9.2-released/index.html
@@ -99,13 +99,13 @@
           
           <ul>
 <li>
+<p>01 Jul 2024 » <a href="/blog/2024-07-01/restic-0.16.5-released/">Restic 0.16.5 Released</a></p>
+</li>
+<li>
 <p>04 Feb 2024 » <a href="/blog/2024-02-04/restic-0.16.4-released/">Restic 0.16.4 Released</a></p>
 </li>
 <li>
 <p>14 Jan 2024 » <a href="/blog/2024-01-14/restic-0.16.3-released/">Restic 0.16.3 Released</a></p>
-</li>
-<li>
-<p>29 Oct 2023 » <a href="/blog/2023-10-29/restic-0.16.2-released/">Restic 0.16.2 Released</a></p>
 </li>
 </ul>
 

--- a/public/blog/2018-09-02/travis-build-cache/index.html
+++ b/public/blog/2018-09-02/travis-build-cache/index.html
@@ -177,13 +177,13 @@ forum</a>)!</p>
           
           <ul>
 <li>
+<p>01 Jul 2024 » <a href="/blog/2024-07-01/restic-0.16.5-released/">Restic 0.16.5 Released</a></p>
+</li>
+<li>
 <p>04 Feb 2024 » <a href="/blog/2024-02-04/restic-0.16.4-released/">Restic 0.16.4 Released</a></p>
 </li>
 <li>
 <p>14 Jan 2024 » <a href="/blog/2024-01-14/restic-0.16.3-released/">Restic 0.16.3 Released</a></p>
-</li>
-<li>
-<p>29 Oct 2023 » <a href="/blog/2023-10-29/restic-0.16.2-released/">Restic 0.16.2 Released</a></p>
 </li>
 </ul>
 

--- a/public/blog/2018-09-09/GitHub-issue-templates/index.html
+++ b/public/blog/2018-09-09/GitHub-issue-templates/index.html
@@ -168,13 +168,13 @@ linked below this article!</p>
           
           <ul>
 <li>
+<p>01 Jul 2024 » <a href="/blog/2024-07-01/restic-0.16.5-released/">Restic 0.16.5 Released</a></p>
+</li>
+<li>
 <p>04 Feb 2024 » <a href="/blog/2024-02-04/restic-0.16.4-released/">Restic 0.16.4 Released</a></p>
 </li>
 <li>
 <p>14 Jan 2024 » <a href="/blog/2024-01-14/restic-0.16.3-released/">Restic 0.16.3 Released</a></p>
-</li>
-<li>
-<p>29 Oct 2023 » <a href="/blog/2023-10-29/restic-0.16.2-released/">Restic 0.16.2 Released</a></p>
 </li>
 </ul>
 

--- a/public/blog/2018-10-13/restic-0.9.3-released/index.html
+++ b/public/blog/2018-10-13/restic-0.9.3-released/index.html
@@ -99,13 +99,13 @@
           
           <ul>
 <li>
+<p>01 Jul 2024 » <a href="/blog/2024-07-01/restic-0.16.5-released/">Restic 0.16.5 Released</a></p>
+</li>
+<li>
 <p>04 Feb 2024 » <a href="/blog/2024-02-04/restic-0.16.4-released/">Restic 0.16.4 Released</a></p>
 </li>
 <li>
 <p>14 Jan 2024 » <a href="/blog/2024-01-14/restic-0.16.3-released/">Restic 0.16.3 Released</a></p>
-</li>
-<li>
-<p>29 Oct 2023 » <a href="/blog/2023-10-29/restic-0.16.2-released/">Restic 0.16.2 Released</a></p>
 </li>
 </ul>
 

--- a/public/blog/2019-01-01/new-infrastructure/index.html
+++ b/public/blog/2019-01-01/new-infrastructure/index.html
@@ -100,13 +100,13 @@
           
           <ul>
 <li>
+<p>01 Jul 2024 » <a href="/blog/2024-07-01/restic-0.16.5-released/">Restic 0.16.5 Released</a></p>
+</li>
+<li>
 <p>04 Feb 2024 » <a href="/blog/2024-02-04/restic-0.16.4-released/">Restic 0.16.4 Released</a></p>
 </li>
 <li>
 <p>14 Jan 2024 » <a href="/blog/2024-01-14/restic-0.16.3-released/">Restic 0.16.3 Released</a></p>
-</li>
-<li>
-<p>29 Oct 2023 » <a href="/blog/2023-10-29/restic-0.16.2-released/">Restic 0.16.2 Released</a></p>
 </li>
 </ul>
 

--- a/public/blog/2019-01-06/restic-0.9.4-released/index.html
+++ b/public/blog/2019-01-06/restic-0.9.4-released/index.html
@@ -103,13 +103,13 @@
           
           <ul>
 <li>
+<p>01 Jul 2024 » <a href="/blog/2024-07-01/restic-0.16.5-released/">Restic 0.16.5 Released</a></p>
+</li>
+<li>
 <p>04 Feb 2024 » <a href="/blog/2024-02-04/restic-0.16.4-released/">Restic 0.16.4 Released</a></p>
 </li>
 <li>
 <p>14 Jan 2024 » <a href="/blog/2024-01-14/restic-0.16.3-released/">Restic 0.16.3 Released</a></p>
-</li>
-<li>
-<p>29 Oct 2023 » <a href="/blog/2023-10-29/restic-0.16.2-released/">Restic 0.16.2 Released</a></p>
 </li>
 </ul>
 

--- a/public/blog/2019-04-23/restic-0.9.5-released/index.html
+++ b/public/blog/2019-04-23/restic-0.9.5-released/index.html
@@ -99,13 +99,13 @@
           
           <ul>
 <li>
+<p>01 Jul 2024 » <a href="/blog/2024-07-01/restic-0.16.5-released/">Restic 0.16.5 Released</a></p>
+</li>
+<li>
 <p>04 Feb 2024 » <a href="/blog/2024-02-04/restic-0.16.4-released/">Restic 0.16.4 Released</a></p>
 </li>
 <li>
 <p>14 Jan 2024 » <a href="/blog/2024-01-14/restic-0.16.3-released/">Restic 0.16.3 Released</a></p>
-</li>
-<li>
-<p>29 Oct 2023 » <a href="/blog/2023-10-29/restic-0.16.2-released/">Restic 0.16.2 Released</a></p>
 </li>
 </ul>
 

--- a/public/blog/2019-11-22/restic-0.9.6-released/index.html
+++ b/public/blog/2019-11-22/restic-0.9.6-released/index.html
@@ -99,13 +99,13 @@
           
           <ul>
 <li>
+<p>01 Jul 2024 » <a href="/blog/2024-07-01/restic-0.16.5-released/">Restic 0.16.5 Released</a></p>
+</li>
+<li>
 <p>04 Feb 2024 » <a href="/blog/2024-02-04/restic-0.16.4-released/">Restic 0.16.4 Released</a></p>
 </li>
 <li>
 <p>14 Jan 2024 » <a href="/blog/2024-01-14/restic-0.16.3-released/">Restic 0.16.3 Released</a></p>
-</li>
-<li>
-<p>29 Oct 2023 » <a href="/blog/2023-10-29/restic-0.16.2-released/">Restic 0.16.2 Released</a></p>
 </li>
 </ul>
 

--- a/public/blog/2020-09-13/rest-server-0.10.0-released/index.html
+++ b/public/blog/2020-09-13/rest-server-0.10.0-released/index.html
@@ -102,13 +102,13 @@
           
           <ul>
 <li>
+<p>01 Jul 2024 » <a href="/blog/2024-07-01/restic-0.16.5-released/">Restic 0.16.5 Released</a></p>
+</li>
+<li>
 <p>04 Feb 2024 » <a href="/blog/2024-02-04/restic-0.16.4-released/">Restic 0.16.4 Released</a></p>
 </li>
 <li>
 <p>14 Jan 2024 » <a href="/blog/2024-01-14/restic-0.16.3-released/">Restic 0.16.3 Released</a></p>
-</li>
-<li>
-<p>29 Oct 2023 » <a href="/blog/2023-10-29/restic-0.16.2-released/">Restic 0.16.2 Released</a></p>
 </li>
 </ul>
 

--- a/public/blog/2020-09-19/restic-0.10.0-released/index.html
+++ b/public/blog/2020-09-19/restic-0.10.0-released/index.html
@@ -112,13 +112,13 @@
           
           <ul>
 <li>
+<p>01 Jul 2024 » <a href="/blog/2024-07-01/restic-0.16.5-released/">Restic 0.16.5 Released</a></p>
+</li>
+<li>
 <p>04 Feb 2024 » <a href="/blog/2024-02-04/restic-0.16.4-released/">Restic 0.16.4 Released</a></p>
 </li>
 <li>
 <p>14 Jan 2024 » <a href="/blog/2024-01-14/restic-0.16.3-released/">Restic 0.16.3 Released</a></p>
-</li>
-<li>
-<p>29 Oct 2023 » <a href="/blog/2023-10-29/restic-0.16.2-released/">Restic 0.16.2 Released</a></p>
 </li>
 </ul>
 

--- a/public/blog/2020-11-05/restic-0.11.0-released/index.html
+++ b/public/blog/2020-11-05/restic-0.11.0-released/index.html
@@ -100,13 +100,13 @@
           
           <ul>
 <li>
+<p>01 Jul 2024 » <a href="/blog/2024-07-01/restic-0.16.5-released/">Restic 0.16.5 Released</a></p>
+</li>
+<li>
 <p>04 Feb 2024 » <a href="/blog/2024-02-04/restic-0.16.4-released/">Restic 0.16.4 Released</a></p>
 </li>
 <li>
 <p>14 Jan 2024 » <a href="/blog/2024-01-14/restic-0.16.3-released/">Restic 0.16.3 Released</a></p>
-</li>
-<li>
-<p>29 Oct 2023 » <a href="/blog/2023-10-29/restic-0.16.2-released/">Restic 0.16.2 Released</a></p>
 </li>
 </ul>
 

--- a/public/blog/2021-02-14/restic-0.12.0-released/index.html
+++ b/public/blog/2021-02-14/restic-0.12.0-released/index.html
@@ -100,13 +100,13 @@
           
           <ul>
 <li>
+<p>01 Jul 2024 » <a href="/blog/2024-07-01/restic-0.16.5-released/">Restic 0.16.5 Released</a></p>
+</li>
+<li>
 <p>04 Feb 2024 » <a href="/blog/2024-02-04/restic-0.16.4-released/">Restic 0.16.4 Released</a></p>
 </li>
 <li>
 <p>14 Jan 2024 » <a href="/blog/2024-01-14/restic-0.16.3-released/">Restic 0.16.3 Released</a></p>
-</li>
-<li>
-<p>29 Oct 2023 » <a href="/blog/2023-10-29/restic-0.16.2-released/">Restic 0.16.2 Released</a></p>
 </li>
 </ul>
 

--- a/public/blog/2021-08-03/restic-0.12.1-released/index.html
+++ b/public/blog/2021-08-03/restic-0.12.1-released/index.html
@@ -100,13 +100,13 @@
           
           <ul>
 <li>
+<p>01 Jul 2024 » <a href="/blog/2024-07-01/restic-0.16.5-released/">Restic 0.16.5 Released</a></p>
+</li>
+<li>
 <p>04 Feb 2024 » <a href="/blog/2024-02-04/restic-0.16.4-released/">Restic 0.16.4 Released</a></p>
 </li>
 <li>
 <p>14 Jan 2024 » <a href="/blog/2024-01-14/restic-0.16.3-released/">Restic 0.16.3 Released</a></p>
-</li>
-<li>
-<p>29 Oct 2023 » <a href="/blog/2023-10-29/restic-0.16.2-released/">Restic 0.16.2 Released</a></p>
 </li>
 </ul>
 

--- a/public/blog/2022-02-10/rest-server-0.11.0-released/index.html
+++ b/public/blog/2022-02-10/rest-server-0.11.0-released/index.html
@@ -99,13 +99,13 @@
           
           <ul>
 <li>
+<p>01 Jul 2024 » <a href="/blog/2024-07-01/restic-0.16.5-released/">Restic 0.16.5 Released</a></p>
+</li>
+<li>
 <p>04 Feb 2024 » <a href="/blog/2024-02-04/restic-0.16.4-released/">Restic 0.16.4 Released</a></p>
 </li>
 <li>
 <p>14 Jan 2024 » <a href="/blog/2024-01-14/restic-0.16.3-released/">Restic 0.16.3 Released</a></p>
-</li>
-<li>
-<p>29 Oct 2023 » <a href="/blog/2023-10-29/restic-0.16.2-released/">Restic 0.16.2 Released</a></p>
 </li>
 </ul>
 

--- a/public/blog/2022-03-26/restic-0.13.0-released/index.html
+++ b/public/blog/2022-03-26/restic-0.13.0-released/index.html
@@ -107,13 +107,13 @@
           
           <ul>
 <li>
+<p>01 Jul 2024 » <a href="/blog/2024-07-01/restic-0.16.5-released/">Restic 0.16.5 Released</a></p>
+</li>
+<li>
 <p>04 Feb 2024 » <a href="/blog/2024-02-04/restic-0.16.4-released/">Restic 0.16.4 Released</a></p>
 </li>
 <li>
 <p>14 Jan 2024 » <a href="/blog/2024-01-14/restic-0.16.3-released/">Restic 0.16.3 Released</a></p>
-</li>
-<li>
-<p>29 Oct 2023 » <a href="/blog/2023-10-29/restic-0.16.2-released/">Restic 0.16.2 Released</a></p>
 </li>
 </ul>
 

--- a/public/blog/2022-04-10/restic-0.13.1-released/index.html
+++ b/public/blog/2022-04-10/restic-0.13.1-released/index.html
@@ -100,13 +100,13 @@
           
           <ul>
 <li>
+<p>01 Jul 2024 » <a href="/blog/2024-07-01/restic-0.16.5-released/">Restic 0.16.5 Released</a></p>
+</li>
+<li>
 <p>04 Feb 2024 » <a href="/blog/2024-02-04/restic-0.16.4-released/">Restic 0.16.4 Released</a></p>
 </li>
 <li>
 <p>14 Jan 2024 » <a href="/blog/2024-01-14/restic-0.16.3-released/">Restic 0.16.3 Released</a></p>
-</li>
-<li>
-<p>29 Oct 2023 » <a href="/blog/2023-10-29/restic-0.16.2-released/">Restic 0.16.2 Released</a></p>
 </li>
 </ul>
 

--- a/public/blog/2022-08-25/restic-0.14.0-released/index.html
+++ b/public/blog/2022-08-25/restic-0.14.0-released/index.html
@@ -111,13 +111,13 @@
           
           <ul>
 <li>
+<p>01 Jul 2024 » <a href="/blog/2024-07-01/restic-0.16.5-released/">Restic 0.16.5 Released</a></p>
+</li>
+<li>
 <p>04 Feb 2024 » <a href="/blog/2024-02-04/restic-0.16.4-released/">Restic 0.16.4 Released</a></p>
 </li>
 <li>
 <p>14 Jan 2024 » <a href="/blog/2024-01-14/restic-0.16.3-released/">Restic 0.16.3 Released</a></p>
-</li>
-<li>
-<p>29 Oct 2023 » <a href="/blog/2023-10-29/restic-0.16.2-released/">Restic 0.16.2 Released</a></p>
 </li>
 </ul>
 

--- a/public/blog/2023-01-12/restic-0.15.0-released/index.html
+++ b/public/blog/2023-01-12/restic-0.15.0-released/index.html
@@ -115,13 +115,13 @@
           
           <ul>
 <li>
+<p>01 Jul 2024 » <a href="/blog/2024-07-01/restic-0.16.5-released/">Restic 0.16.5 Released</a></p>
+</li>
+<li>
 <p>04 Feb 2024 » <a href="/blog/2024-02-04/restic-0.16.4-released/">Restic 0.16.4 Released</a></p>
 </li>
 <li>
 <p>14 Jan 2024 » <a href="/blog/2024-01-14/restic-0.16.3-released/">Restic 0.16.3 Released</a></p>
-</li>
-<li>
-<p>29 Oct 2023 » <a href="/blog/2023-10-29/restic-0.16.2-released/">Restic 0.16.2 Released</a></p>
 </li>
 </ul>
 

--- a/public/blog/2023-01-30/restic-0.15.1-released/index.html
+++ b/public/blog/2023-01-30/restic-0.15.1-released/index.html
@@ -100,13 +100,13 @@
           
           <ul>
 <li>
+<p>01 Jul 2024 » <a href="/blog/2024-07-01/restic-0.16.5-released/">Restic 0.16.5 Released</a></p>
+</li>
+<li>
 <p>04 Feb 2024 » <a href="/blog/2024-02-04/restic-0.16.4-released/">Restic 0.16.4 Released</a></p>
 </li>
 <li>
 <p>14 Jan 2024 » <a href="/blog/2024-01-14/restic-0.16.3-released/">Restic 0.16.3 Released</a></p>
-</li>
-<li>
-<p>29 Oct 2023 » <a href="/blog/2023-10-29/restic-0.16.2-released/">Restic 0.16.2 Released</a></p>
 </li>
 </ul>
 

--- a/public/blog/2023-04-24/rest-server-0.12.0-released/index.html
+++ b/public/blog/2023-04-24/rest-server-0.12.0-released/index.html
@@ -100,13 +100,13 @@
           
           <ul>
 <li>
+<p>01 Jul 2024 » <a href="/blog/2024-07-01/restic-0.16.5-released/">Restic 0.16.5 Released</a></p>
+</li>
+<li>
 <p>04 Feb 2024 » <a href="/blog/2024-02-04/restic-0.16.4-released/">Restic 0.16.4 Released</a></p>
 </li>
 <li>
 <p>14 Jan 2024 » <a href="/blog/2024-01-14/restic-0.16.3-released/">Restic 0.16.3 Released</a></p>
-</li>
-<li>
-<p>29 Oct 2023 » <a href="/blog/2023-10-29/restic-0.16.2-released/">Restic 0.16.2 Released</a></p>
 </li>
 </ul>
 

--- a/public/blog/2023-04-24/restic-0.15.2-released/index.html
+++ b/public/blog/2023-04-24/restic-0.15.2-released/index.html
@@ -101,13 +101,13 @@
           
           <ul>
 <li>
+<p>01 Jul 2024 » <a href="/blog/2024-07-01/restic-0.16.5-released/">Restic 0.16.5 Released</a></p>
+</li>
+<li>
 <p>04 Feb 2024 » <a href="/blog/2024-02-04/restic-0.16.4-released/">Restic 0.16.4 Released</a></p>
 </li>
 <li>
 <p>14 Jan 2024 » <a href="/blog/2024-01-14/restic-0.16.3-released/">Restic 0.16.3 Released</a></p>
-</li>
-<li>
-<p>29 Oct 2023 » <a href="/blog/2023-10-29/restic-0.16.2-released/">Restic 0.16.2 Released</a></p>
 </li>
 </ul>
 

--- a/public/blog/2023-07-09/rest-server-0.12.1-released/index.html
+++ b/public/blog/2023-07-09/rest-server-0.12.1-released/index.html
@@ -100,13 +100,13 @@
           
           <ul>
 <li>
+<p>01 Jul 2024 » <a href="/blog/2024-07-01/restic-0.16.5-released/">Restic 0.16.5 Released</a></p>
+</li>
+<li>
 <p>04 Feb 2024 » <a href="/blog/2024-02-04/restic-0.16.4-released/">Restic 0.16.4 Released</a></p>
 </li>
 <li>
 <p>14 Jan 2024 » <a href="/blog/2024-01-14/restic-0.16.3-released/">Restic 0.16.3 Released</a></p>
-</li>
-<li>
-<p>29 Oct 2023 » <a href="/blog/2023-10-29/restic-0.16.2-released/">Restic 0.16.2 Released</a></p>
 </li>
 </ul>
 

--- a/public/blog/2023-07-31/restic-0.16.0-released/index.html
+++ b/public/blog/2023-07-31/restic-0.16.0-released/index.html
@@ -112,13 +112,13 @@
           
           <ul>
 <li>
+<p>01 Jul 2024 » <a href="/blog/2024-07-01/restic-0.16.5-released/">Restic 0.16.5 Released</a></p>
+</li>
+<li>
 <p>04 Feb 2024 » <a href="/blog/2024-02-04/restic-0.16.4-released/">Restic 0.16.4 Released</a></p>
 </li>
 <li>
 <p>14 Jan 2024 » <a href="/blog/2024-01-14/restic-0.16.3-released/">Restic 0.16.3 Released</a></p>
-</li>
-<li>
-<p>29 Oct 2023 » <a href="/blog/2023-10-29/restic-0.16.2-released/">Restic 0.16.2 Released</a></p>
 </li>
 </ul>
 

--- a/public/blog/2023-10-24/restic-0.16.1-released/index.html
+++ b/public/blog/2023-10-24/restic-0.16.1-released/index.html
@@ -101,13 +101,13 @@
           
           <ul>
 <li>
+<p>01 Jul 2024 » <a href="/blog/2024-07-01/restic-0.16.5-released/">Restic 0.16.5 Released</a></p>
+</li>
+<li>
 <p>04 Feb 2024 » <a href="/blog/2024-02-04/restic-0.16.4-released/">Restic 0.16.4 Released</a></p>
 </li>
 <li>
 <p>14 Jan 2024 » <a href="/blog/2024-01-14/restic-0.16.3-released/">Restic 0.16.3 Released</a></p>
-</li>
-<li>
-<p>29 Oct 2023 » <a href="/blog/2023-10-29/restic-0.16.2-released/">Restic 0.16.2 Released</a></p>
 </li>
 </ul>
 

--- a/public/blog/2023-10-29/restic-0.16.2-released/index.html
+++ b/public/blog/2023-10-29/restic-0.16.2-released/index.html
@@ -101,13 +101,13 @@
           
           <ul>
 <li>
+<p>01 Jul 2024 » <a href="/blog/2024-07-01/restic-0.16.5-released/">Restic 0.16.5 Released</a></p>
+</li>
+<li>
 <p>04 Feb 2024 » <a href="/blog/2024-02-04/restic-0.16.4-released/">Restic 0.16.4 Released</a></p>
 </li>
 <li>
 <p>14 Jan 2024 » <a href="/blog/2024-01-14/restic-0.16.3-released/">Restic 0.16.3 Released</a></p>
-</li>
-<li>
-<p>29 Oct 2023 » <a href="/blog/2023-10-29/restic-0.16.2-released/">Restic 0.16.2 Released</a></p>
 </li>
 </ul>
 

--- a/public/blog/2024-01-14/restic-0.16.3-released/index.html
+++ b/public/blog/2024-01-14/restic-0.16.3-released/index.html
@@ -101,13 +101,13 @@
           
           <ul>
 <li>
+<p>01 Jul 2024 » <a href="/blog/2024-07-01/restic-0.16.5-released/">Restic 0.16.5 Released</a></p>
+</li>
+<li>
 <p>04 Feb 2024 » <a href="/blog/2024-02-04/restic-0.16.4-released/">Restic 0.16.4 Released</a></p>
 </li>
 <li>
 <p>14 Jan 2024 » <a href="/blog/2024-01-14/restic-0.16.3-released/">Restic 0.16.3 Released</a></p>
-</li>
-<li>
-<p>29 Oct 2023 » <a href="/blog/2023-10-29/restic-0.16.2-released/">Restic 0.16.2 Released</a></p>
 </li>
 </ul>
 

--- a/public/blog/2024-02-04/restic-0.16.4-released/index.html
+++ b/public/blog/2024-02-04/restic-0.16.4-released/index.html
@@ -104,13 +104,13 @@
           
           <ul>
 <li>
+<p>01 Jul 2024 » <a href="/blog/2024-07-01/restic-0.16.5-released/">Restic 0.16.5 Released</a></p>
+</li>
+<li>
 <p>04 Feb 2024 » <a href="/blog/2024-02-04/restic-0.16.4-released/">Restic 0.16.4 Released</a></p>
 </li>
 <li>
 <p>14 Jan 2024 » <a href="/blog/2024-01-14/restic-0.16.3-released/">Restic 0.16.3 Released</a></p>
-</li>
-<li>
-<p>29 Oct 2023 » <a href="/blog/2023-10-29/restic-0.16.2-released/">Restic 0.16.2 Released</a></p>
 </li>
 </ul>
 

--- a/public/blog/2024-07-01/restic-0.16.5-released/index.html
+++ b/public/blog/2024-07-01/restic-0.16.5-released/index.html
@@ -14,7 +14,7 @@
   <title>
     restic &middot;
     
-      Meeting at FrOSCon 2017 - Details
+      Restic 0.16.5 Released
     
   </title>
 
@@ -31,7 +31,7 @@
 
   
   
-  <link rel="canonical" href="https://restic.net/blog/2017-08-14/FrOSCon-Bonn-Details/">
+  <link rel="canonical" href="https://restic.net/blog/2024-07-01/restic-0.16.5-released/">
 
   
   <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
@@ -74,17 +74,19 @@
 
     <div class="content container">
       <div class="post">
-        <h1 class="post-title">Meeting at FrOSCon 2017 - Details</h1>
-        <span class="post-date">14 Aug 2017</span>
-        <p>As announced <a href="/blog/2017-07-21/FrOSCon-Bonn/">a few weeks ago</a> we&rsquo;re meeting at this year&rsquo;s <a href="https://www.froscon.de">FrOSCon</a> on 19 August 2017, 15:00 CEST in <a href="https://goo.gl/maps/Rj2Z6ZQfyXK2">Sankt Augustin</a> near Bonn/Cologne in Germany (free entry)! We&rsquo;ll get a project room for the afternoon, the room number will be announced as an update to this blog entry, <a href="https://twitter.com/resticbackup">on Twitter</a> and in <a href="https://forum.restic.net">the forum</a>.</p>
-<p>It&rsquo;d be nice to know how many of you will be able to join us, so please leave a comment in the <a href="https://github.com/restic/restic/issues/1110">GitHub issue #1110</a> or in the forum. We&rsquo;re looking forward to meeting you all, thanks!</p>
+        <h1 class="post-title">Restic 0.16.5 Released</h1>
+        <span class="post-date">01 Jul 2024</span>
+        <p>We are happy to announce the release of <a href="https://github.com/restic/restic/releases/v0.16.5">restic 0.16.5</a>!</p>
+<p>This release updates a few potentially vulnerable dependencies.</p>
+<p>To download the new release and to see a more detailed list of important changes, please head over to <a href="https://github.com/restic/restic/releases/v0.16.5">GitHub</a>. If you already have restic (0.9.4 or later), you can use the <code>self-update</code> command to automatically download and verify the new release.</p>
+<p>As always, thanks for <a href="https://github.com/restic/restic/issues/new/choose">reporting any issues</a> you encounter! To get help or provide feedback, please write a post in <a href="https://forum.restic.net">the forum</a>.</p>
 
       </div>
 
       <h2>Comments</h2>
       <div id='discourse-comments'></div>
       <script type="text/javascript">
-        DiscourseEmbed = { discourseUrl: 'https://forum.restic.net/', discourseEmbedUrl: 'https:\/\/restic.net\/blog\/2017-08-14\/FrOSCon-Bonn-Details\/' };
+        DiscourseEmbed = { discourseUrl: 'https://forum.restic.net/', discourseEmbedUrl: 'https:\/\/restic.net\/blog\/2024-07-01\/restic-0.16.5-released\/' };
 
         (function() {
           var d = document.createElement('script'); d.type = 'text/javascript'; d.async = true;

--- a/public/blog/index.html
+++ b/public/blog/index.html
@@ -80,6 +80,9 @@
         
         <ul>
 <li>
+<p>01 Jul 2024 » <a href="/blog/2024-07-01/restic-0.16.5-released/">Restic 0.16.5 Released</a></p>
+</li>
+<li>
 <p>04 Feb 2024 » <a href="/blog/2024-02-04/restic-0.16.4-released/">Restic 0.16.4 Released</a></p>
 </li>
 <li>

--- a/public/blog/index.xml
+++ b/public/blog/index.xml
@@ -4,10 +4,17 @@
     <title>Blog on restic</title>
     <link>https://restic.net/blog/</link>
     <description>Recent content in Blog on restic</description>
-    <generator>Hugo -- gohugo.io</generator>
+    <generator>Hugo</generator>
     <language>en-us</language>
-    <lastBuildDate>Sun, 04 Feb 2024 00:00:00 +0100</lastBuildDate>
+    <lastBuildDate>Mon, 01 Jul 2024 21:00:00 +0200</lastBuildDate>
     <atom:link href="https://restic.net/blog/index.xml" rel="self" type="application/rss+xml" />
+    <item>
+      <title>Restic 0.16.5 Released</title>
+      <link>https://restic.net/blog/2024-07-01/restic-0.16.5-released/</link>
+      <pubDate>Mon, 01 Jul 2024 21:00:00 +0200</pubDate>
+      <guid>https://restic.net/blog/2024-07-01/restic-0.16.5-released/</guid>
+      <description>We are happy to announce the release of restic 0.16.5!&#xA;This release updates a few potentially vulnerable dependencies.&#xA;To download the new release and to see a more detailed list of important changes, please head over to GitHub. If you already have restic (0.9.4 or later), you can use the self-update command to automatically download and verify the new release.&#xA;As always, thanks for reporting any issues you encounter! To get help or provide feedback, please write a post in the forum.</description>
+    </item>
     <item>
       <title>Restic 0.16.4 Released</title>
       <link>https://restic.net/blog/2024-02-04/restic-0.16.4-released/</link>

--- a/public/categories/index.html
+++ b/public/categories/index.html
@@ -80,6 +80,9 @@
         
         <ul>
 <li>
+<p>01 Jul 2024 » <a href="/blog/2024-07-01/restic-0.16.5-released/">Restic 0.16.5 Released</a></p>
+</li>
+<li>
 <p>04 Feb 2024 » <a href="/blog/2024-02-04/restic-0.16.4-released/">Restic 0.16.4 Released</a></p>
 </li>
 <li>

--- a/public/categories/index.xml
+++ b/public/categories/index.xml
@@ -4,7 +4,7 @@
     <title>Categories on restic</title>
     <link>https://restic.net/categories/</link>
     <description>Recent content in Categories on restic</description>
-    <generator>Hugo -- gohugo.io</generator>
+    <generator>Hugo</generator>
     <language>en-us</language>
     <atom:link href="https://restic.net/categories/index.xml" rel="self" type="application/rss+xml" />
   </channel>

--- a/public/index.html
+++ b/public/index.html
@@ -50,7 +50,7 @@
     </div>
 
     <nav class="sidebar-nav">
-      <a class="sidebar-nav-item" href="https://restic.net/">Home</a>
+      <a class="sidebar-nav-item active" href="https://restic.net/">Home</a>
           <a class="sidebar-nav-item" href="https://restic.net/blog/">Blog</a>
 
       <a class="sidebar-nav-item" href="https://forum.restic.net/">Forum</a>
@@ -156,13 +156,13 @@
 <p>For more information regarding restic development, have a look at <a href="/blog">our blog</a>. The latest posts are:</p>
 <ul>
 <li>
+<p>01 Jul 2024 » <a href="/blog/2024-07-01/restic-0.16.5-released/">Restic 0.16.5 Released</a></p>
+</li>
+<li>
 <p>04 Feb 2024 » <a href="/blog/2024-02-04/restic-0.16.4-released/">Restic 0.16.4 Released</a></p>
 </li>
 <li>
 <p>14 Jan 2024 » <a href="/blog/2024-01-14/restic-0.16.3-released/">Restic 0.16.3 Released</a></p>
-</li>
-<li>
-<p>29 Oct 2023 » <a href="/blog/2023-10-29/restic-0.16.2-released/">Restic 0.16.2 Released</a></p>
 </li>
 </ul>
 <h2 id="license">License</h2>

--- a/public/index.xml
+++ b/public/index.xml
@@ -4,10 +4,17 @@
     <title>Backups done right! on restic</title>
     <link>https://restic.net/</link>
     <description>Recent content in Backups done right! on restic</description>
-    <generator>Hugo -- gohugo.io</generator>
+    <generator>Hugo</generator>
     <language>en-us</language>
-    <lastBuildDate>Sun, 04 Feb 2024 00:00:00 +0100</lastBuildDate>
+    <lastBuildDate>Mon, 01 Jul 2024 21:00:00 +0200</lastBuildDate>
     <atom:link href="https://restic.net/index.xml" rel="self" type="application/rss+xml" />
+    <item>
+      <title>Restic 0.16.5 Released</title>
+      <link>https://restic.net/blog/2024-07-01/restic-0.16.5-released/</link>
+      <pubDate>Mon, 01 Jul 2024 21:00:00 +0200</pubDate>
+      <guid>https://restic.net/blog/2024-07-01/restic-0.16.5-released/</guid>
+      <description>We are happy to announce the release of restic 0.16.5!&#xA;This release updates a few potentially vulnerable dependencies.&#xA;To download the new release and to see a more detailed list of important changes, please head over to GitHub. If you already have restic (0.9.4 or later), you can use the self-update command to automatically download and verify the new release.&#xA;As always, thanks for reporting any issues you encounter! To get help or provide feedback, please write a post in the forum.</description>
+    </item>
     <item>
       <title>Restic 0.16.4 Released</title>
       <link>https://restic.net/blog/2024-02-04/restic-0.16.4-released/</link>

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -3,7 +3,10 @@
   xmlns:xhtml="http://www.w3.org/1999/xhtml">
   <url>
     <loc>https://restic.net/blog/</loc>
-    <lastmod>2024-02-04T00:00:00+01:00</lastmod>
+    <lastmod>2024-07-01T21:00:00+02:00</lastmod>
+  </url><url>
+    <loc>https://restic.net/blog/2024-07-01/restic-0.16.5-released/</loc>
+    <lastmod>2024-07-01T21:00:00+02:00</lastmod>
   </url><url>
     <loc>https://restic.net/blog/2024-02-04/restic-0.16.4-released/</loc>
     <lastmod>2024-02-04T00:00:00+01:00</lastmod>

--- a/public/tags/index.html
+++ b/public/tags/index.html
@@ -80,6 +80,9 @@
         
         <ul>
 <li>
+<p>01 Jul 2024 » <a href="/blog/2024-07-01/restic-0.16.5-released/">Restic 0.16.5 Released</a></p>
+</li>
+<li>
 <p>04 Feb 2024 » <a href="/blog/2024-02-04/restic-0.16.4-released/">Restic 0.16.4 Released</a></p>
 </li>
 <li>

--- a/public/tags/index.xml
+++ b/public/tags/index.xml
@@ -4,7 +4,7 @@
     <title>Tags on restic</title>
     <link>https://restic.net/tags/</link>
     <description>Recent content in Tags on restic</description>
-    <generator>Hugo -- gohugo.io</generator>
+    <generator>Hugo</generator>
     <language>en-us</language>
     <atom:link href="https://restic.net/tags/index.xml" rel="self" type="application/rss+xml" />
   </channel>


### PR DESCRIPTION
Add a minimal blog post for restic 0.16.5. In addition, `.Site.BaseURL` seems to include the trailing slash by now, so I had to adapt all usages. As a bonus, now the currently active page is correctly marked as active in the sidebar.