### PR TITLE
Replace Twitter links with X and Fosstodon equivalents

### DIFF
--- a/content/blog/FrOSCon-Bonn-Details.md
+++ b/content/blog/FrOSCon-Bonn-Details.md
@@ -3,6 +3,6 @@ title: "Meeting at FrOSCon 2017 - Details"
 date: 2017-08-14T00:00:00Z
 ---
 
-As announced [a few weeks ago]({{< relref "FrOSCon-Bonn.md" >}}) we're meeting at this year's [FrOSCon](https://www.froscon.de) on 19 August 2017, 15:00 CEST in [Sankt Augustin](https://goo.gl/maps/Rj2Z6ZQfyXK2) near Bonn/Cologne in Germany (free entry)! We'll get a project room for the afternoon, the room number will be announced as an update to this blog entry, [on Twitter](https://twitter.com/resticbackup) and in [the forum](https://forum.restic.net).
+As announced [a few weeks ago]({{< relref "FrOSCon-Bonn.md" >}}) we're meeting at this year's [FrOSCon](https://www.froscon.de) on 19 August 2017, 15:00 CEST in [Sankt Augustin](https://goo.gl/maps/Rj2Z6ZQfyXK2) near Bonn/Cologne in Germany (free entry)! We'll get a project room for the afternoon, the room number will be announced as an update to this blog entry, [on Fosstodon](https://fosstodon.org/@restic) and in [the forum](https://forum.restic.net).
 
 It'd be nice to know how many of you will be able to join us, so please leave a comment in the [GitHub issue #1110](https://github.com/restic/restic/issues/1110) or in the forum. We're looking forward to meeting you all, thanks!

--- a/content/blog/restic-on-gotime.md
+++ b/content/blog/restic-on-gotime.md
@@ -3,7 +3,7 @@ title: "restic on GoTime #48"
 date: 2017-06-01T00:00:00Z
 ---
 
-Last week [Alex](https://github.com/fd0) had the honour to join [Ashley](https://twitter.com/ashleymcnamara), [Erik](https://twitter.com/erikstmartin), and [Brian](https://twitter.com/bketelsen) at [GoTime](https://changelog.com/gotime). GoTime is a podcast about Go, the community, and everything in between. It was a lot of fun (and he got to do the intro in German). The episode can be found on the [website](https://changelog.com/gotime/48), you can also listen to it right here:
+Last week [Alex](https://github.com/fd0) had the honour to join [Ashley](https://x.com/ashleymcnamara), [Erik](https://x.com/erikstmartin), and [Brian](https://x.com/bketelsen) at [GoTime](https://changelog.com/gotime). GoTime is a podcast about Go, the community, and everything in between. It was a lot of fun (and he got to do the intro in German). The episode can be found on the [website](https://changelog.com/gotime/48), you can also listen to it right here:
 
 <audio data-theme="night" data-src="https://changelog.com/gotime/48/embed" src="https://cdn.changelog.com/uploads/gotime/48/go-time-48.mp3" preload="none" class="changelog-episode" controls></audio><p><a href="https://changelog.com/gotime/48">Go Time 48: Restic and Backups (Done Right) with Alexander Neumann</a> – Listen on <a href="https://changelog.com/">Changelog.com</a></p><script async src="//cdn.changelog.com/embed.js"></script>
 

--- a/public/blog/2017-06-01/restic-on-gotime/index.html
+++ b/public/blog/2017-06-01/restic-on-gotime/index.html
@@ -76,7 +76,7 @@
       <div class="post">
         <h1 class="post-title">restic on GoTime #48</h1>
         <span class="post-date">01 Jun 2017</span>
-        <p>Last week <a href="https://github.com/fd0">Alex</a> had the honour to join <a href="https://twitter.com/ashleymcnamara">Ashley</a>, <a href="https://twitter.com/erikstmartin">Erik</a>, and <a href="https://twitter.com/bketelsen">Brian</a> at <a href="https://changelog.com/gotime">GoTime</a>. GoTime is a podcast about Go, the community, and everything in between. It was a lot of fun (and he got to do the intro in German). The episode can be found on the <a href="https://changelog.com/gotime/48">website</a>, you can also listen to it right here:</p>
+        <p>Last week <a href="https://github.com/fd0">Alex</a> had the honour to join <a href="https://x.com/ashleymcnamara">Ashley</a>, <a href="https://x.com/erikstmartin">Erik</a>, and <a href="https://x.com/bketelsen">Brian</a> at <a href="https://changelog.com/gotime">GoTime</a>. GoTime is a podcast about Go, the community, and everything in between. It was a lot of fun (and he got to do the intro in German). The episode can be found on the <a href="https://changelog.com/gotime/48">website</a>, you can also listen to it right here:</p>
 <p><audio data-theme="night" data-src="https://changelog.com/gotime/48/embed" src="https://cdn.changelog.com/uploads/gotime/48/go-time-48.mp3" preload="none" class="changelog-episode" controls></audio><p><a href="https://changelog.com/gotime/48">Go Time 48: Restic and Backups (Done Right) with Alexander Neumann</a> – Listen on <a href="https://changelog.com/">Changelog.com</a></p><script async src="//cdn.changelog.com/embed.js"></script></p>
 <p>Thank you very much for having Alex on the show!</p>
 

--- a/public/blog/2017-08-14/FrOSCon-Bonn-Details/index.html
+++ b/public/blog/2017-08-14/FrOSCon-Bonn-Details/index.html
@@ -76,7 +76,7 @@
       <div class="post">
         <h1 class="post-title">Meeting at FrOSCon 2017 - Details</h1>
         <span class="post-date">14 Aug 2017</span>
-        <p>As announced <a href="/blog/2017-07-21/FrOSCon-Bonn/">a few weeks ago</a> we&rsquo;re meeting at this year&rsquo;s <a href="https://www.froscon.de">FrOSCon</a> on 19 August 2017, 15:00 CEST in <a href="https://goo.gl/maps/Rj2Z6ZQfyXK2">Sankt Augustin</a> near Bonn/Cologne in Germany (free entry)! We&rsquo;ll get a project room for the afternoon, the room number will be announced as an update to this blog entry, <a href="https://twitter.com/resticbackup">on Twitter</a> and in <a href="https://forum.restic.net">the forum</a>.</p>
+        <p>As announced <a href="/blog/2017-07-21/FrOSCon-Bonn/">a few weeks ago</a> we&rsquo;re meeting at this year&rsquo;s <a href="https://www.froscon.de">FrOSCon</a> on 19 August 2017, 15:00 CEST in <a href="https://goo.gl/maps/Rj2Z6ZQfyXK2">Sankt Augustin</a> near Bonn/Cologne in Germany (free entry)! We&rsquo;ll get a project room for the afternoon, the room number will be announced as an update to this blog entry, <a href="https://fosstodon.org/@restic">on Fosstodon</a> and in <a href="https://forum.restic.net">the forum</a>.</p>
 <p>It&rsquo;d be nice to know how many of you will be able to join us, so please leave a comment in the <a href="https://github.com/restic/restic/issues/1110">GitHub issue #1110</a> or in the forum. We&rsquo;re looking forward to meeting you all, thanks!</p>
 
       </div>

--- a/public/blog/index.xml
+++ b/public/blog/index.xml
@@ -293,7 +293,7 @@
       <link>https://restic.net/blog/2017-08-14/FrOSCon-Bonn-Details/</link>
       <pubDate>Mon, 14 Aug 2017 00:00:00 +0000</pubDate>
       <guid>https://restic.net/blog/2017-08-14/FrOSCon-Bonn-Details/</guid>
-      <description>As announced a few weeks ago we&amp;rsquo;re meeting at this year&amp;rsquo;s FrOSCon on 19 August 2017, 15:00 CEST in Sankt Augustin near Bonn/Cologne in Germany (free entry)! We&amp;rsquo;ll get a project room for the afternoon, the room number will be announced as an update to this blog entry, on Twitter and in the forum.&#xA;It&amp;rsquo;d be nice to know how many of you will be able to join us, so please leave a comment in the GitHub issue #1110 or in the forum.</description>
+      <description>As announced a few weeks ago we&amp;rsquo;re meeting at this year&amp;rsquo;s FrOSCon on 19 August 2017, 15:00 CEST in Sankt Augustin near Bonn/Cologne in Germany (free entry)! We&amp;rsquo;ll get a project room for the afternoon, the room number will be announced as an update to this blog entry, on Fosstodon and in the forum.&#xA;It&amp;rsquo;d be nice to know how many of you will be able to join us, so please leave a comment in the GitHub issue #1110 or in the forum.</description>
     </item>
     <item>
       <title>Discourse Forum</title>

--- a/public/index.xml
+++ b/public/index.xml
@@ -293,7 +293,7 @@
       <link>https://restic.net/blog/2017-08-14/FrOSCon-Bonn-Details/</link>
       <pubDate>Mon, 14 Aug 2017 00:00:00 +0000</pubDate>
       <guid>https://restic.net/blog/2017-08-14/FrOSCon-Bonn-Details/</guid>
-      <description>As announced a few weeks ago we&amp;rsquo;re meeting at this year&amp;rsquo;s FrOSCon on 19 August 2017, 15:00 CEST in Sankt Augustin near Bonn/Cologne in Germany (free entry)! We&amp;rsquo;ll get a project room for the afternoon, the room number will be announced as an update to this blog entry, on Twitter and in the forum.&#xA;It&amp;rsquo;d be nice to know how many of you will be able to join us, so please leave a comment in the GitHub issue #1110 or in the forum.</description>
+      <description>As announced a few weeks ago we&amp;rsquo;re meeting at this year&amp;rsquo;s FrOSCon on 19 August 2017, 15:00 CEST in Sankt Augustin near Bonn/Cologne in Germany (free entry)! We&amp;rsquo;ll get a project room for the afternoon, the room number will be announced as an update to this blog entry, on Fosstodon and in the forum.&#xA;It&amp;rsquo;d be nice to know how many of you will be able to join us, so please leave a comment in the GitHub issue #1110 or in the forum.</description>
     </item>
     <item>
       <title>Discourse Forum</title>


### PR DESCRIPTION
The Twitter links were failing the link checker because of way too many redirects. Better just replace them.